### PR TITLE
Updated readme to reflect current docs state

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,142 +8,30 @@
 # MetaSynth
 MetaSynth is a Python package designed to generate tabular synthetic data for rigorous code testing and reproducibility.
 
-The package has two main functionalities. First, it allows for the **creation of metadata** from an input dataset. This metadata describes the overarching structure and traits of the dataset. Second, MetaSynth allows for **generation of synthetic data** that aligns with this metadata. Instead of relying on the original dataset, the synthetic data is produced using the metadata. This approach ensures that the synthetic dataset remains separate and independent from any sensitive source data. Researchers and data owners can leverage this capability to generate and share synthetic versions of their sensitive data, mitigating privacy concerns. Furthermore, this separation between metadata and original data promotes reproducibility, as the metadata file can be easily shared and used to generate consistent synthetic datasets.
+The package has three main functionalities:
 
+1. **Estimation**: MetaSynth can create a MetaFrame, from a dataset. A MetaFrame is essentially a fitted model that characterizes the structure of the original dataset without storing actual values. It captures individual distributions and features, enabling generation of synthetic data based on these MetaFrames and can be seen as (statistical) metadata.
+2. **Serialization**: MetaSynth can export a MetaFrame into an easy to read JSON file, allowing users to audit, understand, and modify their data generation model.
+3. **Generation**: MetaSynth can generate synthetic data based on a MetaFrame. The synthetic data produced solely depends on the MetaFrame, thereby maintaining a critical separation between the original sensitive data and the synthetic data generated. The generated synthetic data, emulates the original data's format and plausibility at the individual record level and attempts to reproduce marginal (univariate) distributions where possible. Generated values are based on the observed distributions while adding a degree of variance and smoothing. The generated data does **not** aim to preserve the relationships between variables. The frequency of missing values and their codes are maintained in the synthetically-augmented dataset. 
 
-## Features
-### Generating metadata from a dataset
-MetaSynth can generate metadata from any given dataset (provided as polars or pandas dataframe) in the form of a MetaFrame. A MetaFrame encapsulates the structure and characteristics of each column in the original dataset (including their names, variable types, data types, proportion of missing values and distribution specifications) and serves as complete recipes for generating new synthetic data. 
+Researchers and data owners can use MetaSynth to generate and share synthetic versions of their sensitive datasets, mitigating privacy concerns. Additionally, MetaSynth facilitates transparency and reproducibility, by allowing the underlying MetaFrames to be exported and shared. Other researchers can use these to regenerate consistent synthetic datasets, validating published work without requiring sensitive data.
 
-MetaFrames follow the GMF standard, [Generative Metadata Format (GMF)](https://github.com/sodascience/generative_metadata_format) and as such are designed to be easy to read. MetaFrames can be exported as .JSON file allowing for manual and automatic editing, as well as easy sharing.
+![MetaSynth Pipeline](docs/source/images/pipeline_basic.png)
 
-![Metadata_generation_flowchart](docs/source/images/flow_metadata_generation.png)
+### Key features
+-   **MetaFrame Generation**: MetaSynth allows the creation of a MetaFrame from a dataset provided as a Polars or Pandas DataFrame.
+    MetaFrames includes key characteristics such as *variable names*, *data types*, *the percentage of missing values*, and *distribution parameters*.
+-   **Exporting MetaFrames**: MetaSynth can export and import MetaFrames to GMF files. These are JSON files that follow the easy to read and understand [Generative Metadata Format (GMF)](https://github.com/sodascience/generative_metadata_format).
+-   **Synthetic Data Generation**: MetaSynth allows for the generation of a polars DataFrame with synthetic data that resembles the original data.
+-   **Distribution Fitting**: MetaSynth allows for manual and automatic distribution fitting.
+-   **Data Type Support**: MetaSynth supports generating synthetic data for a variety of common data types including `categorical`, `string`, `integer`, `float`, `date`, `time`, and `datetime`.
+-   **Integration with Faker**: MetaSynth integrates with the [faker](https://github.com/joke2k/faker) package, a Python library for generating fake data such as names and emails. Allowing for more realistic synthetic data.
+-   **Structured String Detection**: MetaSynth identifies structured strings within your dataset, which can include formatted text,
+    codes, identifiers, or any string that follows a specific pattern.
+-   **Handling Unique Values**: MetaSynth can identify and process variables with unique values or keys in the data, preserving their uniqueness in the synthetic dataset, which is crucial for generating synthetic data that maintains the characteristics of the original
+    dataset.
 
-<details> 
-<summary> A simple example of an exported MetaFrame (following the GMF standard): </summary>
-
-```json
- {
-    "n_rows": 5,
-    "n_columns": 5,
-    "provenance": {
-        "created by": {
-            "name": "MetaSynth",
-            "version": "0.4.0"
-        },
-        "creation time": "2023-08-07T12:04:40.669740"
-    },
-    "vars": [
-        {
-            "name": "ID",
-            "type": "discrete",
-            "dtype": "Int64",
-            "prop_missing": 0.0,
-            "distribution": {
-                "implements": "core.unique_key",
-                "provenance": "builtin",
-                "class_name": "UniqueKeyDistribution",
-                "parameters": {
-                    "low": 1,
-                    "consecutive": 1
-                }
-            }
-        },
-        {
-            "name": "fruits",
-            "type": "categorical",
-            "dtype": "Categorical",
-            "prop_missing": 0.0,
-            "distribution": {
-                "implements": "core.multinoulli",
-                "provenance": "builtin",
-                "class_name": "MultinoulliDistribution",
-                "parameters": {
-                    "labels": [
-                        "apple",
-                        "banana"
-                    ],
-                    "probs": [
-                        0.4,
-                        0.6
-                    ]
-                }
-            }
-        },
-        {
-            "name": "B",
-            "type": "discrete",
-            "dtype": "Int64",
-            "prop_missing": 0.0,
-            "distribution": {
-                "implements": "core.poisson",
-                "provenance": "builtin",
-                "class_name": "PoissonDistribution",
-                "parameters": {
-                    "mu": 3.0
-                }
-            }
-        },
-        {
-            "name": "cars",
-            "type": "categorical",
-            "dtype": "Categorical",
-            "prop_missing": 0.0,
-            "distribution": {
-                "implements": "core.multinoulli",
-                "provenance": "builtin",
-                "class_name": "MultinoulliDistribution",
-                "parameters": {
-                    "labels": [
-                        "audi",
-                        "beetle"
-                    ],
-                    "probs": [
-                        0.2,
-                        0.8
-                    ]
-                }
-            }
-        },
-        {
-            "name": "optional",
-            "type": "discrete",
-            "dtype": "Int64",
-            "prop_missing": 0.2,
-            "distribution": {
-                "implements": "core.discrete_uniform",
-                "provenance": "builtin",
-                "class_name": "DiscreteUniformDistribution",
-                "parameters": {
-                    "low": -30,
-                    "high": 301
-                }
-            }
-        }
-    ]
-}
-```
-
-A more advanced example GMF, based on the [Titanic](https://raw.githubusercontent.com/pandas-dev/pandas/main/doc/data/titanic.csv) dataset, can be found [here](examples/titanic_example.json)
-</details>
-
-### Generating synthetic data from a GMF file
-MetaSynth can then be used to **generate synthetic data** from any GMF standard .JSON file.
-
-![Synthetic_data_generation](docs/source/images/flow_synthetic_data_generation.png)
-
-The generated synthetic data, emulates the original data's format and plausibility at the individual record level and attempts to reproduce marginal (univariate) distributions where possible. Generated values are based on the observed distributions while adding a degree of variance and smoothing. The generated data does **not** aim to preserve the relationships between variables. The frequency of missing values and their codes are maintained in the synthetically-augmented dataset. 
-
-### Overview of features
-- **Metadata Generation**: MetaSynth allows the extraction of metadata from a dataset provided as a Polars or Pandas dataframe. Metadata includes key characteristics such as variable names, types, data types, the percentage of missing values, and distribution attributes.
-- **Synthetic Data Generation**: MetaSynth allows for the generation of a polars DataFrame with synthetic data that resembles the original data.
-- **GMF Standard**: MetaSynth utilizes the Generative Metadata Format (GMF) standard for metadata export and import. 
-- **Distribution Fitting**: MetaSynth allows for manual and automatic distribution fitting.
-- **Data Type Support**: MetaSynth supports generating synthetic data for a variety of common data types including `categorical`, `string`, `integer`, `float`, `date`, `time`, and `datetime`.
-- **Integration with Faker**: MetaSynth integrates with the [faker](https://github.com/joke2k/faker) package, a Python library for generating fake data such as names and emails. Allowing for more realistic synthetic data.    
-- **Structured String Detection**: MetaSynth identifies structured strings within your dataset, which can include formatted text, codes, identifiers, or any string that follows a specific pattern.
-- **Handling Unique Values**: MetaSynth can identify and process variables with unique values or keys in the data, preserving their uniqueness in the synthetic dataset, which is crucial for generating synthetic data that maintains the characteristics of the original dataset.
-
+Curious and want to learn more? Check out our[documentation](https://metasynth.readthedocs.io/en/latest/index.html)!
 
 ## Getting Started
 ### Try it out online
@@ -161,7 +49,7 @@ pip install metasynth
 
 To learn how to use MetaSynth effectively, refer to the comprehensive [documentation](https://metasynth.readthedocs.io/en/latest/index.html). The documentation covers all the necessary information and provides detailed explanations, examples, and usage guidelines.
 
-Additionally, the documentation offers a series of [tutorials](https://metasynth.readthedocs.io/en/latest/index.html) that delve into specific features and use cases. These tutorials can further assist you in understanding and leveraging the capabilities of MetaSynth.
+Additionally, the documentation offers a series of [tutorials](https://metasynth.readthedocs.io/en/latest/usage/interactive_tutorials.html) that delve into specific features and use cases. These tutorials can further assist you in understanding and leveraging the capabilities of MetaSynth.
 
 ### Quick start
 Get started quickly with MetaSynth using the following example. In this concise demonstration, you'll learn the basic functionality of MetaSynth by generating synthetic data from [titanic](https://raw.githubusercontent.com/pandas-dev/pandas/main/doc/data/titanic.csv) dataset.
@@ -174,7 +62,7 @@ import polars as pl
 from metasynth import MetaFrame, demo_file
 ```
 
-#### Generating a MetaFrame 
+#### Estimation: Generating a MetaFrame 
 ##### 1.  Begin by creating a polars dataframe:
 ```python
 # import the demo csv 
@@ -213,28 +101,30 @@ be easily converted back to a Pandas DataFrame by using `df_pandas = df_polars.t
 mf = MetaFrame.fit_dataframe(df)
 ```
 
-> Note: if at this point you get the following warning about a potential unique variable, do not worry, it is safe to continue.
+> Note: If you encounter a warning about `PassengerId` not being set as unique, you can safely ignore it and proceed. This warning occurs because `PassengerId` appears to contain unique values, but is not explicitly marked as a unique column. To remove the warning, you can set `PassengerId` to be a unique column. Our documentation explains how to do this when generating Metaframes: [Set Columns as Unique](https://metasynth.readthedocs.io/en/latest/usage/generating_metaframes.html#optional-parameters).
 > 
 > ```
 > Variable PassengerId seems unique, but not set to be unique. Set the variable to be either unique or not unique to remove this warning. warnings.warn(f"\nVariable {series.name} seems unique, but not set to be unique.\n"
 > ```
 
-##### 3. We can export this MetaFrame to a .JSON file using:
+#### (De)serialization: Exporting and importing a MetaFrame 
+_Note that exporting and importing is optional. You can generate synthetic data from **any** loaded MetaFrame, whether that be through importing a GMF file or generating a MetaFrame from an original DataFrame._
+
+##### 3. We can export this MetaFrame to a GMF file using:
 
 ```python
 #export MetaFrame
-mf.to_json("exported_metaframe.json")
+mf.export("exported_metaframe.json")
 ```
 
-#### Generating synthetic data
-
-##### 1. We can load metadata from a .JSON file:
+##### 4. Similarly, we can import a MetaFrame from a GMF file using:
 ```python
 # load MetaFrame
 mf = MetaFrame.from_json("exported_metaframe.json")
 ```
 
-##### 2. We can then synthesize a DataFrame based on a loaded MetaFrame using:
+#### Generation: Generating synthetic data
+##### 5. Finally, we can generate a DataFrame with synthetic data based on a MetaFrame using:
 
 ```python
 # synthesize a DataFrame with 5 rows of data based on a MetaFrame

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 # MetaSynth
 MetaSynth is a Python package designed to generate tabular synthetic data for rigorous code testing and reproducibility.
+Researchers and data owners can use MetaSynth to generate and share synthetic versions of their sensitive datasets, mitigating privacy concerns. Additionally, MetaSynth facilitates transparency and reproducibility, by allowing the underlying MetaFrames to be exported and shared. Other researchers can use these to regenerate consistent synthetic datasets, validating published work without requiring sensitive data.
 
 The package has three main functionalities:
 
@@ -14,22 +15,128 @@ The package has three main functionalities:
 2. **Serialization**: MetaSynth can export a MetaFrame into an easy to read JSON file, allowing users to audit, understand, and modify their data generation model.
 3. **Generation**: MetaSynth can generate synthetic data based on a MetaFrame. The synthetic data produced solely depends on the MetaFrame, thereby maintaining a critical separation between the original sensitive data and the synthetic data generated. The generated synthetic data, emulates the original data's format and plausibility at the individual record level and attempts to reproduce marginal (univariate) distributions where possible. Generated values are based on the observed distributions while adding a degree of variance and smoothing. The generated data does **not** aim to preserve the relationships between variables. The frequency of missing values and their codes are maintained in the synthetically-augmented dataset. 
 
-Researchers and data owners can use MetaSynth to generate and share synthetic versions of their sensitive datasets, mitigating privacy concerns. Additionally, MetaSynth facilitates transparency and reproducibility, by allowing the underlying MetaFrames to be exported and shared. Other researchers can use these to regenerate consistent synthetic datasets, validating published work without requiring sensitive data.
-
 ![MetaSynth Pipeline](docs/source/images/pipeline_basic.png)
 
 ### Key features
 -   **MetaFrame Generation**: MetaSynth allows the creation of a MetaFrame from a dataset provided as a Polars or Pandas DataFrame.
     MetaFrames includes key characteristics such as *variable names*, *data types*, *the percentage of missing values*, and *distribution parameters*.
 -   **Exporting MetaFrames**: MetaSynth can export and import MetaFrames to GMF files. These are JSON files that follow the easy to read and understand [Generative Metadata Format (GMF)](https://github.com/sodascience/generative_metadata_format).
+
+    <details> 
+    <summary> A simple example of an exported MetaFrame (following the GMF standard): </summary>
+
+    ```json
+    {
+        "n_rows": 5,
+        "n_columns": 5,
+        "provenance": {
+            "created by": {
+                "name": "MetaSynth",
+                "version": "0.4.0"
+            },
+            "creation time": "2023-08-07T12:04:40.669740"
+        },
+        "vars": [
+            {
+                "name": "ID",
+                "type": "discrete",
+                "dtype": "Int64",
+                "prop_missing": 0.0,
+                "distribution": {
+                    "implements": "core.unique_key",
+                    "provenance": "builtin",
+                    "class_name": "UniqueKeyDistribution",
+                    "parameters": {
+                        "low": 1,
+                        "consecutive": 1
+                    }
+                }
+            },
+            {
+                "name": "fruits",
+                "type": "categorical",
+                "dtype": "Categorical",
+                "prop_missing": 0.0,
+                "distribution": {
+                    "implements": "core.multinoulli",
+                    "provenance": "builtin",
+                    "class_name": "MultinoulliDistribution",
+                    "parameters": {
+                        "labels": [
+                            "apple",
+                            "banana"
+                        ],
+                        "probs": [
+                            0.4,
+                            0.6
+                        ]
+                    }
+                }
+            },
+            {
+                "name": "B",
+                "type": "discrete",
+                "dtype": "Int64",
+                "prop_missing": 0.0,
+                "distribution": {
+                    "implements": "core.poisson",
+                    "provenance": "builtin",
+                    "class_name": "PoissonDistribution",
+                    "parameters": {
+                        "mu": 3.0
+                    }
+                }
+            },
+            {
+                "name": "cars",
+                "type": "categorical",
+                "dtype": "Categorical",
+                "prop_missing": 0.0,
+                "distribution": {
+                    "implements": "core.multinoulli",
+                    "provenance": "builtin",
+                    "class_name": "MultinoulliDistribution",
+                    "parameters": {
+                        "labels": [
+                            "audi",
+                            "beetle"
+                        ],
+                        "probs": [
+                            0.2,
+                            0.8
+                        ]
+                    }
+                }
+            },
+            {
+                "name": "optional",
+                "type": "discrete",
+                "dtype": "Int64",
+                "prop_missing": 0.2,
+                "distribution": {
+                    "implements": "core.discrete_uniform",
+                    "provenance": "builtin",
+                    "class_name": "DiscreteUniformDistribution",
+                    "parameters": {
+                        "low": -30,
+                        "high": 301
+                    }
+                }
+            }
+        ]
+    }
+    ```
+
+    A more advanced example GMF, based on the [Titanic](https://raw.githubusercontent.com/pandas-dev/pandas/main/doc/data/titanic.csv) dataset, can be found [here](examples/titanic_example.json)
+    </details>
+
 -   **Synthetic Data Generation**: MetaSynth allows for the generation of a polars DataFrame with synthetic data that resembles the original data.
 -   **Distribution Fitting**: MetaSynth allows for manual and automatic distribution fitting.
 -   **Data Type Support**: MetaSynth supports generating synthetic data for a variety of common data types including `categorical`, `string`, `integer`, `float`, `date`, `time`, and `datetime`.
--   **Integration with Faker**: MetaSynth integrates with the [faker](https://github.com/joke2k/faker) package, a Python library for generating fake data such as names and emails. Allowing for more realistic synthetic data.
+-   **Integration with Faker**: MetaSynth integrates with the [faker](https://github.com/joke2k/faker) package, a Python library for generating fake data such as names and emails. Allowing for synthetic data that is formatted realistically, while retaining privacy.
 -   **Structured String Detection**: MetaSynth identifies structured strings within your dataset, which can include formatted text,
     codes, identifiers, or any string that follows a specific pattern.
--   **Handling Unique Values**: MetaSynth can identify and process variables with unique values or keys in the data, preserving their uniqueness in the synthetic dataset, which is crucial for generating synthetic data that maintains the characteristics of the original
-    dataset.
+-   **Handling Unique Values**: MetaSynth can identify and process variables with unique values or keys in the data, preserving their uniqueness in the synthetic dataset, which is crucial for generating synthetic data that maintains the characteristics of the original dataset.
 
 Curious and want to learn more? Check out our[documentation](https://metasynth.readthedocs.io/en/latest/index.html)!
 
@@ -38,7 +145,6 @@ Curious and want to learn more? Check out our[documentation](https://metasynth.r
 If you're new to Python or simply want to quickly explore the basic features of MetaSynth, you can try it out using the online Google Colab tutorial. [Click here](https://colab.research.google.com/github/sodascience/metasynth/blob/main/examples/getting_started.ipynb) to access the tutorial. It provides a step-by-step walkthrough and example dataset to help you get started. However, please exercise caution when using sensitive data, as it will be handled through Google servers.
 
 ### Local Installation
-
 For more advanced users and researchers who prefer working on their local machines, you can install MetaSynth directly from PyPI using the following command in the terminal (not Python):
 
 ```sh
@@ -46,7 +152,6 @@ pip install metasynth
 ```
 
 ## Usage
-
 To learn how to use MetaSynth effectively, refer to the comprehensive [documentation](https://metasynth.readthedocs.io/en/latest/index.html). The documentation covers all the necessary information and provides detailed explanations, examples, and usage guidelines.
 
 Additionally, the documentation offers a series of [tutorials](https://metasynth.readthedocs.io/en/latest/usage/interactive_tutorials.html) that delve into specific features and use cases. These tutorials can further assist you in understanding and leveraging the capabilities of MetaSynth.
@@ -67,7 +172,6 @@ from metasynth import MetaFrame, demo_file
 ```python
 # import the demo csv 
 dataset_csv = demo_file() # This function automatically loads the Titanic dataset (as found here )
-
 
 # create dataframe
 data_types = {
@@ -101,11 +205,7 @@ be easily converted back to a Pandas DataFrame by using `df_pandas = df_polars.t
 mf = MetaFrame.fit_dataframe(df)
 ```
 
-> Note: If you encounter a warning about `PassengerId` not being set as unique, you can safely ignore it and proceed. This warning occurs because `PassengerId` appears to contain unique values, but is not explicitly marked as a unique column. To remove the warning, you can set `PassengerId` to be a unique column. Our documentation explains how to do this when generating Metaframes: [Set Columns as Unique](https://metasynth.readthedocs.io/en/latest/usage/generating_metaframes.html#optional-parameters).
-> 
-> ```
-> Variable PassengerId seems unique, but not set to be unique. Set the variable to be either unique or not unique to remove this warning. warnings.warn(f"\nVariable {series.name} seems unique, but not set to be unique.\n"
-> ```
+> Note: At this point you will encounter a warning about `PassengerId` not being set as unique, you can safely ignore it and proceed. This warning occurs because `PassengerId` appears to contain unique values, but is not explicitly marked as a unique column. To remove the warning, you can set `PassengerId` to be a unique column. Our documentation explains how to do this when generating Metaframes: [Set Columns as Unique](https://metasynth.readthedocs.io/en/latest/usage/generating_metaframes.html#optional-parameters).
 
 #### (De)serialization: Exporting and importing a MetaFrame 
 _Note that exporting and importing is optional. You can generate synthetic data from **any** loaded MetaFrame, whether that be through importing a GMF file or generating a MetaFrame from an original DataFrame._
@@ -113,7 +213,7 @@ _Note that exporting and importing is optional. You can generate synthetic data 
 ##### 3. We can export this MetaFrame to a GMF file using:
 
 ```python
-#export MetaFrame
+# export MetaFrame
 mf.export("exported_metaframe.json")
 ```
 
@@ -130,8 +230,6 @@ mf = MetaFrame.from_json("exported_metaframe.json")
 # synthesize a DataFrame with 5 rows of data based on a MetaFrame
 synthetic_data = mf.synthesize(5) 
 ```
-
-
 
 <!-- CONTRIBUTING -->
 ## Contributing


### PR DESCRIPTION
- Condensed irrelevant information
- referred to the docs in the introduction
- Adapted the pipeline as now explained on the docs
- Changed 'to_json' (function) to 'export'
- Mentioned GMF files more (as opposed to .JSON files)
- improved the warning message on 'unique' values

Improved warning message + grammatical error fixes

Solves #163 