### PR TITLE
added an easier way to preview a metaframe's gmf

### DIFF
--- a/metasyn/metaframe.py
+++ b/metasyn/metaframe.py
@@ -302,6 +302,11 @@ class MetaFrame():
         output = json.dumps(pretty_data, indent=4)
         return output
 
+    def gmf_preview(self):
+        """Print a preview of the MetaFrame in the GMF format."""
+        print(self.__repr__())
+
+
 
 def _jsonify(data):
     if isinstance(data, (list, tuple)):


### PR DESCRIPTION
Previously the following syntax had to be used to print the gmf preview of the file:

```
gmf_preview = repr(mf)
print(gmf_preview)
```

A new method `gmf_preview` has been added to allow for easier syntax: `mf.gmf_preview()`