### PR TITLE
Add create-meta subcommand

### DIFF
--- a/metasyn/__main__.py
+++ b/metasyn/__main__.py
@@ -92,7 +92,7 @@ def create_metadata():
     )
     parser.add_argument(
         "input",
-        help="input file; a csv file that you want to synthesize later.",
+        help="input file; a CSV file that you want to synthesize later.",
         type=pathlib.Path,
     )
     parser.add_argument(

--- a/metasyn/__main__.py
+++ b/metasyn/__main__.py
@@ -23,7 +23,7 @@ Usage: metasyn [subcommand] [options]
 
 Available subcommands:
     create-meta - generate a GMF/json file.
-    synthesize - generate synthetic data from a .json file
+    synthesize - generate synthetic data from a GMF (.json) file 
     jsonschema - generate json schema from distribution providers
 
 Program information:

--- a/metasyn/__main__.py
+++ b/metasyn/__main__.py
@@ -23,7 +23,7 @@ Usage: metasyn [subcommand] [options]
 
 Available subcommands:
     create-meta - generate a GMF (.json) file.
-    synthesize - generate synthetic data from a GMF (.json) file 
+    synthesize - generate synthetic data from a GMF (.json) file
     jsonschema - generate json schema from distribution providers
 
 Program information:
@@ -85,7 +85,7 @@ def _parse_config(config_fp):
 
 
 def create_metadata():
-    """Program to create and export metadata from a DataFrame into a GMF file (.json)."""
+    """Program to create and export metadata from a DataFrame to a GMF file (.json)."""
     parser = argparse.ArgumentParser(
         prog="metasyn create-meta",
         description="Create a Generative Metadata Format file from a CSV file.",

--- a/metasyn/__main__.py
+++ b/metasyn/__main__.py
@@ -22,7 +22,7 @@ Metasyn CLI version {version("metasyn")}
 Usage: metasyn [subcommand] [options]
 
 Available subcommands:
-    create-meta - generate a GMF/json file.
+    create-meta - generate a GMF (.json) file.
     synthesize - generate synthetic data from a GMF (.json) file 
     jsonschema - generate json schema from distribution providers
 

--- a/metasyn/__main__.py
+++ b/metasyn/__main__.py
@@ -85,7 +85,7 @@ def _parse_config(config_fp):
 
 
 def create_metadata():
-    """Program to create metadata from a dataframe."""
+    """Program to create and export metadata from a DataFrame into a GMF file (.json)."""
     parser = argparse.ArgumentParser(
         prog="metasyn create-meta",
         description="Create a Generative Metadata Format file from a CSV file.",


### PR DESCRIPTION
This adds a command to complete the whole pipeline from the command line.

I have added an INI parser to set the specs. An INI file is not ideal, because it has not nesting. However, it is easier to work with than JSON/YAML files, for which you can easily create parsing errors.

fixes #143 