### PR TITLE
Added documentation on printing and previewing MetaFrames / GMFs

### DIFF
--- a/docs/source/usage/exporting_metaframes.rst
+++ b/docs/source/usage/exporting_metaframes.rst
@@ -135,6 +135,14 @@ The following code exports a generated :obj:`MetaFrame<metasyn.metaframe.MetaFra
 
 |break|
 
+    
+It is possible to preview the GMF file, without having to export it. This can be done by calling the Python built-in :func:`repr <python:repr>` function on a :obj:`MetaFrame<metasyn.metaframe.MetaFrame>` object, and printing its output.
+
+.. code-block:: python
+
+    gmf_preview = repr(mf)
+    print(gmf_preview)
+
 Loading a MetaFrame
 -------------------
 You can load a MetaFrame from a GMF file using the :meth:`MetaFrame.from_json <metasyn.metaframe.MetaFrame.from_json>` classmethod. 

--- a/docs/source/usage/generating_metaframes.rst
+++ b/docs/source/usage/generating_metaframes.rst
@@ -15,7 +15,7 @@ One of the main features of metasyn is to create a :obj:`MetaFrame <metasyn.meta
 .. admonition:: Command-line Interface
 
     It is also possible to generate a MetaFrame, based on a given GMF file, using the metasyn command-line interface. For instructions on how to do so, see the :doc:`/usage/cli` page.
-
+   
 Basics
 ------
 
@@ -34,6 +34,14 @@ This function requires a :obj:`DataFrame` to be specified as parameter. The foll
 .. admonition:: Note on Pandas and Polars DataFrames
 
     Internally, metasyn uses Polars (instead of Pandas) mainly because typing and the handling of non-existing data is more consistent. It is possible to supply a Pandas DataFrame instead of a Polars DataFrame to the ``MetaFrame.from_dataframe`` method. However, this uses the automatic Polars conversion functionality, which for some edge cases result in problems. Therefore, we advise users to create Polars DataFrames. The resulting synthetic dataset is always a Polars DataFrame, but this can be easily converted back to a Pandas DataFrame by using ``df_pandas = df_polars.to_pandas()``.
+
+
+It is possible to print the (statistical metadata contained in the) :obj:`MetaFrame <metasyn.metaframe.MetaFrame>` to the console/output log. This can simply be done by calling the Python built-in `print` function on a :obj:`MetaFrame <metasyn.metaframe.MetaFrame>`:
+
+.. code-block:: python
+
+    print(mf)
+
 
 .. _OptionalParams:
 


### PR DESCRIPTION
Very small PR, the docs now show that it's possible to print the statistical metadata in a MF, as well as how the `repr` can be used to show the to-be gmf file.

solves #190 