### PR TITLE
Change it so that dt distribution inherit from base

### DIFF
--- a/metasyn/distribution/datetime.py
+++ b/metasyn/distribution/datetime.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 
 import numpy as np
 
-from metasyn.distribution.base import ScipyDistribution, metadist
+from metasyn.distribution.base import BaseDistribution, metadist
 
 
 def convert_numpy_datetime(time_obj: np.datetime64) -> dt.datetime:
@@ -29,7 +29,7 @@ def convert_numpy_datetime(time_obj: np.datetime64) -> dt.datetime:
     return dt.datetime.utcfromtimestamp(float(seconds_since_epoch))
 
 
-class BaseUniformDistribution(ScipyDistribution):
+class BaseUniformDistribution(BaseDistribution):
     """Base class for all time/date/datetime uniform distributions."""
 
     precision_possibilities = ["microseconds", "seconds", "minutes", "hours", "days"]
@@ -43,11 +43,7 @@ class BaseUniformDistribution(ScipyDistribution):
             end = self.fromisoformat(end)
         elif isinstance(end, np.datetime64):
             end = convert_numpy_datetime(end)
-        self.par = {
-            "start": start,
-            "end": end,
-            "precision": precision,
-        }
+        self.precision = precision
         self.start = self.round(start)
         self.end = self.round(end)
 


### PR DESCRIPTION
It doesn't make any sense that it would derive from the ScipyDistribution. It was only using some attribute trickery, which is not necessary at all.