### PR TITLE
Remove notebook checking for osx

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,6 +54,6 @@ jobs:
       run: |
         pytest tests
     - name: Check notebook output
-      if: ${{ matrix.os }}  != "macos-latest"
+      if: ${{ matrix.os != "macos-latest" }}
       run: |
         pytest --nbval-lax examples

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,5 +54,6 @@ jobs:
       run: |
         pytest tests
     - name: Check notebook output
+      if: ${{ matrix.os }}  != "macos-latest"
       run: |
         pytest --nbval-lax examples

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,6 +54,6 @@ jobs:
       run: |
         pytest tests
     - name: Check notebook output
-      if: ${{ matrix.os != "macos-latest" }}
+      if: ${{ matrix.os != 'macos-latest' }}
       run: |
         pytest --nbval-lax examples

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ author = 'SODA Team'
 
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.0'
+release = '0.7.1'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This will skip the test to check the notebooks on mac OS, which can fail (still). Fixes #263 