### PR TITLE
Fixes an issue with distspec and privacy

### DIFF
--- a/metasyn/config.py
+++ b/metasyn/config.py
@@ -65,7 +65,7 @@ class MetaConfig():
     @privacy.setter
     def privacy(self, privacy):
         if privacy is None:
-            self._privacy = BasicPrivacy()
+            self._privacy: BasePrivacy = BasicPrivacy()
         elif isinstance(privacy, dict):
             self._privacy = get_privacy(**privacy)
         else:

--- a/metasyn/provider.py
+++ b/metasyn/provider.py
@@ -203,7 +203,7 @@ class DistributionProviderList():
     def fit(self, series: pl.Series,
             var_type: str,
             dist_spec: DistributionSpec,
-            privacy: BasePrivacy = BasicPrivacy()):
+            privacy: BasePrivacy = BasicPrivacy()) -> BaseDistribution:
         """Fit a distribution to a column/series.
 
         Parameters
@@ -220,6 +220,8 @@ class DistributionProviderList():
         privacy:
             Level of privacy that will be used in the fit.
         """
+        if dist_spec.distribution is not None:
+            return dist_spec.distribution
         if dist_spec.implements is not None:
             return self._fit_distribution(series, dist_spec, var_type, privacy)
         return self._find_best_fit(series, var_type, dist_spec.unique, privacy)

--- a/metasyn/util.py
+++ b/metasyn/util.py
@@ -30,6 +30,7 @@ class DistributionSpec():
     parameters: Optional[dict] = None
     fit_kwargs: dict = field(default_factory=dict)
     version: Optional[str] = None
+    distribution: Optional[str] = None
 
     def __post_init__(self):
         if self.implements is None:
@@ -71,7 +72,7 @@ class DistributionSpec():
         if isinstance(dist_spec, BaseDistribution):
             dist_dict = {key: value for key, value in dist_spec.to_dict().items()
                          if key in ["implements", "version", "unique", "parameters"]}
-            return cls(**dist_dict)
+            return cls(**dist_dict, distribution=dist_spec)
         if isinstance(dist_spec, str):
             return cls(implements=dist_spec, unique=unique)
         if dist_spec is None:

--- a/metasyn/util.py
+++ b/metasyn/util.py
@@ -30,7 +30,7 @@ class DistributionSpec():
     parameters: Optional[dict] = None
     fit_kwargs: dict = field(default_factory=dict)
     version: Optional[str] = None
-    distribution: Optional[str] = None
+    distribution: Optional[BaseDistribution] = None
 
     def __post_init__(self):
         if self.implements is None:


### PR DESCRIPTION
Currently, if the distribution is supplied, but the privacy plugin doesn't have that distribution type, there will be shown an error. This fixes that issue and should make the disclosure privacy plugin succeed in it Ci test again.