### PR TITLE
Plugin registry

### DIFF
--- a/examples/example_gmf_simple.json
+++ b/examples/example_gmf_simple.json
@@ -4,9 +4,9 @@
     "provenance": {
         "created by": {
             "name": "metasyn",
-            "version": "0.6.1.dev45+g6cfcb6d.d20240131"
+            "version": "0.8.1.dev0+ge481025.d20240325"
         },
-        "creation time": "2024-01-31T11:52:33.761957"
+        "creation time": "2024-03-25T17:06:53.455575"
     },
     "vars": [
         {
@@ -22,14 +22,18 @@
                 "unique": true,
                 "parameters": {
                     "lower": 1,
-                    "consecutive": 1
+                    "consecutive": true
                 }
+            },
+            "creation_method": {
+                "created_by": "metasyn",
+                "unique": true
             }
         },
         {
             "name": "fruits",
             "type": "categorical",
-            "dtype": "Categorical",
+            "dtype": "Categorical(ordering='physical')",
             "prop_missing": 0.0,
             "distribution": {
                 "implements": "core.multinoulli",
@@ -47,6 +51,9 @@
                         0.6
                     ]
                 }
+            },
+            "creation_method": {
+                "created_by": "metasyn"
             }
         },
         {
@@ -55,21 +62,25 @@
             "dtype": "Int64",
             "prop_missing": 0.0,
             "distribution": {
-                "implements": "core.unique_key",
+                "implements": "core.uniform",
                 "version": "1.0",
                 "provenance": "builtin",
-                "class_name": "UniqueKeyDistribution",
-                "unique": true,
+                "class_name": "DiscreteUniformDistribution",
+                "unique": false,
                 "parameters": {
                     "lower": 1,
-                    "consecutive": 0
+                    "upper": 6
                 }
+            },
+            "creation_method": {
+                "created_by": "metasyn",
+                "unique": false
             }
         },
         {
             "name": "cars",
             "type": "categorical",
-            "dtype": "Categorical",
+            "dtype": "Categorical(ordering='physical')",
             "prop_missing": 0.0,
             "distribution": {
                 "implements": "core.multinoulli",
@@ -87,6 +98,9 @@
                         0.8
                     ]
                 }
+            },
+            "creation_method": {
+                "created_by": "metasyn"
             }
         },
         {
@@ -95,25 +109,18 @@
             "dtype": "Int64",
             "prop_missing": 0.2,
             "distribution": {
-                "implements": "core.multinoulli",
+                "implements": "core.uniform",
                 "version": "1.0",
                 "provenance": "builtin",
-                "class_name": "MultinoulliDistribution",
+                "class_name": "DiscreteUniformDistribution",
                 "unique": false,
                 "parameters": {
-                    "labels": [
-                        -30,
-                        2,
-                        28,
-                        300
-                    ],
-                    "probs": [
-                        0.25,
-                        0.25,
-                        0.25,
-                        0.25
-                    ]
+                    "lower": -30,
+                    "upper": 301
                 }
+            },
+            "creation_method": {
+                "created_by": "metasyn"
             }
         }
     ]

--- a/metasyn/__init__.py
+++ b/metasyn/__init__.py
@@ -23,8 +23,8 @@ from importlib.metadata import version
 from metasyn.demo.dataset import demo_dataframe, demo_file
 from metasyn.distribution.base import metadist
 from metasyn.metaframe import MetaFrame
-from metasyn.util import VarSpec
 from metasyn.var import MetaVar
+from metasyn.varspec import VarSpec
 
 __all__ = ["MetaVar", "MetaFrame", "demo_file", "demo_dataframe", "metadist", "VarSpec"]
 __version__ = version("metasyn")

--- a/metasyn/config.py
+++ b/metasyn/config.py
@@ -193,4 +193,3 @@ class VarSpecAccess():  # pylint: disable=too-few-public-methods
         if attr not in ("var_spec", "meta_config") and hasattr(self.var_spec, attr):
             return getattr(self.var_spec, attr)
         return super().__getattribute__(attr)
-

--- a/metasyn/config.py
+++ b/metasyn/config.py
@@ -9,8 +9,6 @@ try:
 except ImportError:
     import tomli as tomllib  # type: ignore  # noqa
 
-import tomllib
-
 from metasyn.privacy import BasePrivacy, BasicPrivacy, get_privacy
 from metasyn.provider import DistributionProviderList
 from metasyn.varspec import VarSpec
@@ -65,7 +63,7 @@ class MetaConfig():
         return self._privacy
 
     @privacy.setter
-    def privacy(self, privacy):
+    def privacy(self, privacy: Optional[Union[dict, BasePrivacy]]):
         if privacy is None:
             self._privacy: BasePrivacy = BasicPrivacy()
         elif isinstance(privacy, dict):

--- a/metasyn/config.py
+++ b/metasyn/config.py
@@ -9,9 +9,11 @@ try:
 except ImportError:
     import tomli as tomllib  # type: ignore  # noqa
 
+import tomllib
+
 from metasyn.privacy import BasePrivacy, BasicPrivacy, get_privacy
 from metasyn.provider import DistributionProviderList
-from metasyn.util import VarSpec
+from metasyn.varspec import VarSpec
 
 
 class MetaConfig():
@@ -191,3 +193,4 @@ class VarSpecAccess():  # pylint: disable=too-few-public-methods
         if attr not in ("var_spec", "meta_config") and hasattr(self.var_spec, attr):
             return getattr(self.var_spec, attr)
         return super().__getattribute__(attr)
+

--- a/metasyn/metaframe.py
+++ b/metasyn/metaframe.py
@@ -14,9 +14,9 @@ from tqdm import tqdm
 
 from metasyn.config import MetaConfig
 from metasyn.privacy import BasePrivacy
-from metasyn.util import VarSpec
 from metasyn.validation import validate_gmf_dict
 from metasyn.var import MetaVar
+from metasyn.varspec import VarSpec
 
 
 class MetaFrame():

--- a/metasyn/privacy.py
+++ b/metasyn/privacy.py
@@ -3,19 +3,13 @@
 from abc import ABC, abstractmethod
 from typing import Optional, Type, Union
 
-import tomllib
-
 try:
     from importlib_metadata import entry_points
 except ImportError:
     from importlib.metadata import entry_points  # type: ignore
 
-try:
-    from importlib_resources import files
-except ImportError:
-    from importlib.resources import files  # type: ignore
-
 from metasyn.distribution.base import BaseDistribution
+from metasyn.util import get_registry
 
 
 class BasePrivacy(ABC):
@@ -98,9 +92,7 @@ def get_privacy(name: str, parameters: Optional[dict] = None) -> BasePrivacy:
             return entry.load()(**parameters)
 
     # Handle case where the plugin is not installed or is misspelled.
-    registry_fp = files(__package__) / "schema" / "plugin_registry.toml"
-    with open(registry_fp, "rb") as handle:
-        registry = tomllib.load(handle)
+    registry = get_registry()
     available_plugins = {key: val for key, val in registry.items() if name in val["privacy"]}
     if len(available_plugins) > 0:
         avail = "\n".join(f"{key}: {val['url']}" for key, val in available_plugins.items())

--- a/metasyn/provider.py
+++ b/metasyn/provider.py
@@ -55,7 +55,8 @@ from metasyn.distribution.faker import (
 from metasyn.distribution.na import NADistribution
 from metasyn.distribution.regex import RegexDistribution, UniqueRegexDistribution
 from metasyn.privacy import BasePrivacy, BasicPrivacy
-from metasyn.util import DistributionSpec, get_registry
+from metasyn.util import get_registry
+from metasyn.varspec import DistributionSpec
 
 if TYPE_CHECKING:
     from metasyn.config import VarSpec, VarSpecAccess

--- a/metasyn/provider.py
+++ b/metasyn/provider.py
@@ -527,4 +527,5 @@ def get_distribution_provider(
         if provider not in registry:
             raise ValueError(f"Cannot find distribution provider with name '{provider}'.") from exc
         raise ValueError(f"Distribution provider '{provider}' is not installed.\n"
-                         f"See {registry['provider']['url']} for installation instructions.")
+                         f"See {registry['provider']['url']} for installation instructions."
+                         ) from exc

--- a/metasyn/provider.py
+++ b/metasyn/provider.py
@@ -55,7 +55,7 @@ from metasyn.distribution.faker import (
 from metasyn.distribution.na import NADistribution
 from metasyn.distribution.regex import RegexDistribution, UniqueRegexDistribution
 from metasyn.privacy import BasePrivacy, BasicPrivacy
-from metasyn.util import DistributionSpec
+from metasyn.util import DistributionSpec, get_registry
 
 if TYPE_CHECKING:
     from metasyn.config import VarSpec, VarSpecAccess
@@ -339,6 +339,15 @@ class DistributionProviderList():
             if dist_class.matches_name(dist_name)]
 
         if len(legacy_distribs+versions_found) == 0:
+            registry = get_registry()
+            available = {}
+            for plugin, meta in registry.items():
+                if dist_name in meta["distributions"]:
+                    available[plugin] = meta["url"]
+            if len(available) > 0:
+                avail_str = "\n".join("{plugin}: {url}" for plugin, url in available.items())
+                raise ValueError(f"Distribution with name '{dist_name}' not installed.\n"
+                                 f"Possible sources:\n\n{avail_str}\n")
             raise ValueError(f"Cannot find distribution with name '{dist_name}'.")
 
         if len(versions_found) == 0:
@@ -513,4 +522,8 @@ def get_distribution_provider(
     try:
         return all_providers[provider].load()()
     except KeyError as exc:
-        raise ValueError(f"Cannot find distribution provider with name '{provider}'.") from exc
+        registry = get_registry()
+        if provider not in registry:
+            raise ValueError(f"Cannot find distribution provider with name '{provider}'.") from exc
+        raise ValueError(f"Distribution provider '{provider}' is not installed.\n"
+                         f"See {registry['provider']['url']} for installation instructions.")

--- a/metasyn/schema/plugin_registry.toml
+++ b/metasyn/schema/plugin_registry.toml
@@ -1,0 +1,5 @@
+[disclosure]
+
+url = "https://github.com/sodascience/metasyn-disclosure-control"
+privacy = ["disclosure"]
+distributions = []

--- a/metasyn/util.py
+++ b/metasyn/util.py
@@ -1,7 +1,10 @@
 """Utility module for metasyn."""
 from __future__ import annotations
 
-import tomllib
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore  # noqa
 
 try:
     from importlib_resources import files

--- a/metasyn/util.py
+++ b/metasyn/util.py
@@ -6,13 +6,7 @@ specifications.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any, Optional, Union
-
 import tomllib
-
-from metasyn.distribution.base import BaseDistribution
-from metasyn.privacy import BasePrivacy, BasicPrivacy, get_privacy
 
 try:
     from importlib_resources import files
@@ -20,198 +14,16 @@ except ImportError:
     from importlib.resources import files  # type: ignore
 
 
-@dataclass
-class DistributionSpec():
-    """Specification that determines which distribution is selected.
+def get_registry() -> dict:
+    """Get the registry dictionary from the package.
 
-    It has the following attributes:
-    - implements: Which distribution is chosen.
-    - unique: Whether the distribution should be unique.
-    - parameters: The parameters of the distribution as defined by implements.
-    - fit_kwargs: Fitting keyword arguments to be used while fitting the distribution.
-    - version: Version of the distribution to fit.
+    This registry contains information on plugins that are available for metasyn.
+
+    Returns
+    -------
+        Dictionary containing the registry entries.
     """
-
-    implements: Optional[str] = None
-    unique: Optional[bool] = None
-    parameters: Optional[dict] = None
-    fit_kwargs: dict = field(default_factory=dict)
-    version: Optional[str] = None
-    distribution: Optional[BaseDistribution] = None
-
-    def __post_init__(self):
-        if self.implements is None:
-            if self.version is not None:
-                raise ValueError("Cannot create DistributionSpec with attribute 'version' but "
-                                 "without attribute 'implements'.")
-            if self.parameters is not None:
-                raise ValueError("Cannot create DistributionSpec with attribute 'parameters' but "
-                                 "without attribute 'implements'.")
-            if len(self.fit_kwargs) > 0:
-                raise ValueError("Cannot create DistributionSpec with attribute 'fit_kwargs' that"
-                                 " is not empty but without attribute 'implements'.")
-
-
-    @classmethod
-    def parse(cls, dist_spec: Optional[Union[dict, type[BaseDistribution], BaseDistribution,
-                                             DistributionSpec, str]],
-              unique: Optional[bool] = None,
-              ) -> DistributionSpec:
-        """Create a DistributionSpec instance from a variety of inputs.
-
-        Parameters
-        ----------
-        dist_spec:
-            Specification for the distribution in several types.
-        unique:
-            Whether the distribution is unique. This is only taken into account
-            if dist_spec is None or a string.
-
-        Returns
-        -------
-            A instantiated version of the dist_spec that has the DistributionSpec type.
-
-        Raises
-        ------
-        TypeError
-            If the input has the wrong type and cannot be parsed.
-        """
-        if isinstance(dist_spec, BaseDistribution):
-            dist_dict = {key: value for key, value in dist_spec.to_dict().items()
-                         if key in ["implements", "version", "unique", "parameters"]}
-            return cls(**dist_dict, distribution=dist_spec)
-        if isinstance(dist_spec, str):
-            return cls(implements=dist_spec, unique=unique)
-        if dist_spec is None:
-            return cls(unique=unique)
-        if isinstance(dist_spec, dict):
-            return cls(**dist_spec)
-        if isinstance(dist_spec, DistributionSpec):
-            return dist_spec
-        if issubclass(dist_spec, BaseDistribution):
-            return cls(implements=dist_spec.implements, unique=dist_spec.unique)
-        raise TypeError("Error parsing distribution specification of unknown type "
-                        f"'{type(dist_spec)}' with value '{dist_spec}'")
-
-    @property
-    def fully_specified(self) -> bool:
-        """Indicate whether the distribution is suitable for datafree creation.
-
-        Returns
-        -------
-            A flag that indicates whether a distribution can be generated from the values
-            that are specified (not None).
-        """
-        return self.implements is not None and self.parameters is not None
-
-    def get_creation_method(self, privacy: BasePrivacy) -> dict:
-        """Create a dictionary on how the distribution was created.
-
-        Parameters
-        ----------
-        privacy
-            Privacy object with which the dictionary is being created.
-
-        Returns
-        -------
-            Dictionary containing all the non-default settings for the creation method.
-        """
-        ret_dict: dict[str, Any] = {"created_by": "metasyn"}
-        for var in ["implements", "unique", "parameters", "version"]:
-            if getattr(self, var) is not None:
-                ret_dict[var] = getattr(self, var)
-        if len(self.fit_kwargs) > 0:
-            ret_dict["fit_kwargs"] = self.fit_kwargs
-        if not isinstance(privacy, BasicPrivacy):
-            ret_dict["privacy"] = privacy.to_dict()
-        return ret_dict
-
-
-class VarSpec():  # pylint: disable=too-few-public-methods
-    """Data class for storing the specifications for variables.
-
-    Parameters
-    ----------
-    name:
-        Name of the variable/column.
-    distribution, optional:
-        Distribution to use for fitting/finding the distribution.
-        Leave at None to allow metasyn to find the most suitable distribution
-        automatically.
-
-        >>> # Use normal distribution
-        >>> distribution="normal"
-        >>> # Use normal distribution with mean 0, standard deviation 1
-        >>> distribution=NormalDistribution(0, 1)
-
-    unique, optional:
-        To set a column to be unique/key.
-        This is only available for the integer and string datatypes. Setting a variable
-        to unique ensures that the synthetic values generated for this variable are unique.
-        This is useful for ID or primary key variables, for example. The parameter...
-        is ignored when the distribution is set manually. For example:
-        {"unique": True}, which sets the variable to be unique or {"unique": False} which
-        forces the variable to be not unique. If the uniqueness is not specified, it is
-        assumed to be not unique, but gives a warning if metasyn thinks it should be.
-    privacy, optional:
-        Set the privacy level for a variable, e.g.: DifferentialPrivacy(epsilon=10).
-    prop_missing, optional:
-        Proportion of missing values for a variable.
-    description, optional:
-        Set the description of a variable.
-    data_free, optional:
-        Whether this variable/column is to be generated from scratch or from an existing column
-        in the dataframe.
-    var_type, optional:
-        Manually set the variable type of the columns (used mainly for data_free columns).
-    """
-
-    def __init__(
-            self,
-            name: str,
-            distribution: Optional[Union[dict, type[BaseDistribution], BaseDistribution,
-                                                DistributionSpec, str]] = None,
-            unique=None,
-            privacy: Optional[BasePrivacy] = None,
-            prop_missing: Optional[float] = None,
-            description: Optional[str] = None,
-            data_free: bool = False,
-            var_type: Optional[str] = None):
-
-        self.name = name
-        self.dist_spec = DistributionSpec.parse(distribution, unique)
-        self.privacy = privacy
-        self.prop_missing = prop_missing
-        self.description = description
-        self.data_free = data_free
-        self.var_type = var_type
-        self.__post_init__()
-
-    def __post_init__(self):
-        # Convert the the privacy attribute if it is a dictionary.
-        if isinstance(self.privacy, dict):
-            self.privacy = get_privacy(**self.privacy)
-        if self.data_free and not self.dist_spec.fully_specified:
-            raise ValueError("Error creating variable specification: data free variable should have"
-                            f" 'implements' and 'parameters'. {self}")
-
-    @classmethod
-    def from_dict(cls, var_dict: dict) -> VarSpec:
-        """Create a variable specification from a dictionary.
-
-        Parameters
-        ----------
-        var_dict
-            Dictionary to parse the specification from.
-
-        Returns
-        -------
-            A VarSpec instance.
-        """
-        return cls(**var_dict)
-
-
-def get_registry():
     registry_fp = files(__package__) / "schema" / "plugin_registry.toml"
     with open(registry_fp, "rb") as handle:
         registry = tomllib.load(handle)
+    return registry

--- a/metasyn/util.py
+++ b/metasyn/util.py
@@ -9,8 +9,15 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Optional, Union
 
+import tomllib
+
 from metasyn.distribution.base import BaseDistribution
 from metasyn.privacy import BasePrivacy, BasicPrivacy, get_privacy
+
+try:
+    from importlib_resources import files
+except ImportError:
+    from importlib.resources import files  # type: ignore
 
 
 @dataclass
@@ -202,3 +209,9 @@ class VarSpec():  # pylint: disable=too-few-public-methods
             A VarSpec instance.
         """
         return cls(**var_dict)
+
+
+def get_registry():
+    registry_fp = files(__package__) / "schema" / "plugin_registry.toml"
+    with open(registry_fp, "rb") as handle:
+        registry = tomllib.load(handle)

--- a/metasyn/util.py
+++ b/metasyn/util.py
@@ -1,9 +1,4 @@
-"""Utility module for metasyn.
-
-This module provides utility classes that are used across metasyn,
-including classes for specifying distributions and storing variable
-specifications.
-"""
+"""Utility module for metasyn."""
 from __future__ import annotations
 
 import tomllib

--- a/metasyn/var.py
+++ b/metasyn/var.py
@@ -10,7 +10,7 @@ import polars as pl
 from metasyn.distribution.base import BaseDistribution
 from metasyn.privacy import BasePrivacy, BasicPrivacy
 from metasyn.provider import BaseDistributionProvider, DistributionProviderList
-from metasyn.util import DistributionSpec
+from metasyn.varspec import DistributionSpec
 
 
 class MetaVar():

--- a/metasyn/varspec.py
+++ b/metasyn/varspec.py
@@ -1,16 +1,9 @@
-
+"""Module for distribution and variable specifications."""
 from __future__ import annotations
-
-from typing import Optional, Union
-
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib  # type: ignore  # noqa
 
 # from metasyn.util import VarSpec
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Optional, Union
 
 from metasyn.distribution.base import BaseDistribution
 from metasyn.privacy import BasePrivacy, BasicPrivacy, get_privacy

--- a/metasyn/varspec.py
+++ b/metasyn/varspec.py
@@ -1,0 +1,207 @@
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore  # noqa
+
+# from metasyn.util import VarSpec
+from dataclasses import dataclass, field
+from typing import Any
+
+from metasyn.distribution.base import BaseDistribution
+from metasyn.privacy import BasePrivacy, BasicPrivacy, get_privacy
+
+
+@dataclass
+class DistributionSpec():
+    """Specification that determines which distribution is selected.
+
+    It has the following attributes:
+    - implements: Which distribution is chosen.
+    - unique: Whether the distribution should be unique.
+    - parameters: The parameters of the distribution as defined by implements.
+    - fit_kwargs: Fitting keyword arguments to be used while fitting the distribution.
+    - version: Version of the distribution to fit.
+    """
+
+    implements: Optional[str] = None
+    unique: Optional[bool] = None
+    parameters: Optional[dict] = None
+    fit_kwargs: dict = field(default_factory=dict)
+    version: Optional[str] = None
+    distribution: Optional[BaseDistribution] = None
+
+    def __post_init__(self):
+        if self.implements is None:
+            if self.version is not None:
+                raise ValueError("Cannot create DistributionSpec with attribute 'version' but "
+                                 "without attribute 'implements'.")
+            if self.parameters is not None:
+                raise ValueError("Cannot create DistributionSpec with attribute 'parameters' but "
+                                 "without attribute 'implements'.")
+            if len(self.fit_kwargs) > 0:
+                raise ValueError("Cannot create DistributionSpec with attribute 'fit_kwargs' that"
+                                 " is not empty but without attribute 'implements'.")
+
+
+    @classmethod
+    def parse(cls, dist_spec: Optional[Union[dict, type[BaseDistribution], BaseDistribution,
+                                             DistributionSpec, str]],
+              unique: Optional[bool] = None,
+              ) -> DistributionSpec:
+        """Create a DistributionSpec instance from a variety of inputs.
+
+        Parameters
+        ----------
+        dist_spec:
+            Specification for the distribution in several types.
+        unique:
+            Whether the distribution is unique. This is only taken into account
+            if dist_spec is None or a string.
+
+        Returns
+        -------
+            A instantiated version of the dist_spec that has the DistributionSpec type.
+
+        Raises
+        ------
+        TypeError
+            If the input has the wrong type and cannot be parsed.
+        """
+        if isinstance(dist_spec, BaseDistribution):
+            dist_dict = {key: value for key, value in dist_spec.to_dict().items()
+                         if key in ["implements", "version", "unique", "parameters"]}
+            return cls(**dist_dict, distribution=dist_spec)
+        if isinstance(dist_spec, str):
+            return cls(implements=dist_spec, unique=unique)
+        if dist_spec is None:
+            return cls(unique=unique)
+        if isinstance(dist_spec, dict):
+            return cls(**dist_spec)
+        if isinstance(dist_spec, DistributionSpec):
+            return dist_spec
+        if issubclass(dist_spec, BaseDistribution):
+            return cls(implements=dist_spec.implements, unique=dist_spec.unique)
+        raise TypeError("Error parsing distribution specification of unknown type "
+                        f"'{type(dist_spec)}' with value '{dist_spec}'")
+
+    @property
+    def fully_specified(self) -> bool:
+        """Indicate whether the distribution is suitable for datafree creation.
+
+        Returns
+        -------
+            A flag that indicates whether a distribution can be generated from the values
+            that are specified (not None).
+        """
+        return self.implements is not None and self.parameters is not None
+
+    def get_creation_method(self, privacy: BasePrivacy) -> dict:
+        """Create a dictionary on how the distribution was created.
+
+        Parameters
+        ----------
+        privacy
+            Privacy object with which the dictionary is being created.
+
+        Returns
+        -------
+            Dictionary containing all the non-default settings for the creation method.
+        """
+        ret_dict: dict[str, Any] = {"created_by": "metasyn"}
+        for var in ["implements", "unique", "parameters", "version"]:
+            if getattr(self, var) is not None:
+                ret_dict[var] = getattr(self, var)
+        if len(self.fit_kwargs) > 0:
+            ret_dict["fit_kwargs"] = self.fit_kwargs
+        if not isinstance(privacy, BasicPrivacy):
+            ret_dict["privacy"] = privacy.to_dict()
+        return ret_dict
+
+
+class VarSpec():  # pylint: disable=too-few-public-methods
+    """Data class for storing the specifications for variables.
+
+    Parameters
+    ----------
+    name:
+        Name of the variable/column.
+    distribution, optional:
+        Distribution to use for fitting/finding the distribution.
+        Leave at None to allow metasyn to find the most suitable distribution
+        automatically.
+
+        >>> # Use normal distribution
+        >>> distribution="normal"
+        >>> # Use normal distribution with mean 0, standard deviation 1
+        >>> distribution=NormalDistribution(0, 1)
+
+    unique, optional:
+        To set a column to be unique/key.
+        This is only available for the integer and string datatypes. Setting a variable
+        to unique ensures that the synthetic values generated for this variable are unique.
+        This is useful for ID or primary key variables, for example. The parameter...
+        is ignored when the distribution is set manually. For example:
+        {"unique": True}, which sets the variable to be unique or {"unique": False} which
+        forces the variable to be not unique. If the uniqueness is not specified, it is
+        assumed to be not unique, but gives a warning if metasyn thinks it should be.
+    privacy, optional:
+        Set the privacy level for a variable, e.g.: DifferentialPrivacy(epsilon=10).
+    prop_missing, optional:
+        Proportion of missing values for a variable.
+    description, optional:
+        Set the description of a variable.
+    data_free, optional:
+        Whether this variable/column is to be generated from scratch or from an existing column
+        in the dataframe.
+    var_type, optional:
+        Manually set the variable type of the columns (used mainly for data_free columns).
+    """
+
+    def __init__(
+            self,
+            name: str,
+            distribution: Optional[Union[dict, type[BaseDistribution], BaseDistribution,
+                                                DistributionSpec, str]] = None,
+            unique=None,
+            privacy: Optional[BasePrivacy] = None,
+            prop_missing: Optional[float] = None,
+            description: Optional[str] = None,
+            data_free: bool = False,
+            var_type: Optional[str] = None):
+
+        self.name = name
+        self.dist_spec = DistributionSpec.parse(distribution, unique)
+        self.privacy = privacy
+        self.prop_missing = prop_missing
+        self.description = description
+        self.data_free = data_free
+        self.var_type = var_type
+        self.__post_init__()
+
+    def __post_init__(self):
+        # Convert the the privacy attribute if it is a dictionary.
+        if isinstance(self.privacy, dict):
+            self.privacy = get_privacy(**self.privacy)
+        if self.data_free and not self.dist_spec.fully_specified:
+            raise ValueError("Error creating variable specification: data free variable should have"
+                            f" 'implements' and 'parameters'. {self}")
+
+    @classmethod
+    def from_dict(cls, var_dict: dict) -> VarSpec:
+        """Create a variable specification from a dictionary.
+
+        Parameters
+        ----------
+        var_dict
+            Dictionary to parse the specification from.
+
+        Returns
+        -------
+            A VarSpec instance.
+        """
+        return cls(**var_dict)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from pytest import mark
 from metasyn.config import MetaConfig, VarSpecAccess
 from metasyn.distribution import UniformDistribution
 from metasyn.privacy import BasePrivacy
-from metasyn.util import DistributionSpec, VarSpec
+from metasyn.varspec import DistributionSpec, VarSpec
 
 
 @mark.parametrize(

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,6 +1,8 @@
+import pytest
+
 from metasyn.distribution import MultinoulliDistribution
 from metasyn.distribution.base import metadist
-from metasyn.privacy import BasicPrivacy
+from metasyn.privacy import BasicPrivacy, get_privacy
 
 
 @metadist(privacy="test")
@@ -19,3 +21,10 @@ def test_base_privacy():
     assert privacy.is_compatible(MultinoulliDistribution)
     assert privacy.is_compatible(MultinoulliDistribution(["1"], [1.0]))
     assert not privacy.is_compatible(OtherMultinoulli)
+
+
+def test_import_error():
+    with pytest.raises(ImportError):
+        get_privacy("disclosure")
+    with pytest.raises(ImportError):
+        get_privacy("dics")


### PR DESCRIPTION
Registry for plugins contained in the package to ensure better error messages. It also moves the `util.py` file to `varspec.py`.

Fixes #284 