### PR TITLE
Ignore Mypy error

### DIFF
--- a/metasyn/distribution/base.py
+++ b/metasyn/distribution/base.py
@@ -343,7 +343,7 @@ class UniqueDistributionMixin(BaseDistribution):
     def draw(self) -> object:
         n_retry = 0
         while n_retry < 1e5:
-            new_val = super().draw()
+            new_val = super().draw()  # type: ignore
             if new_val not in self.key_set:
                 self.key_set.add(new_val)
                 return new_val


### PR DESCRIPTION
I don't think in our case this is any issue. This is only a problem if you try to create a distribution without implementing draw. Normally, this should be no issue, since there is always a distribution that represents the non-unique version.