### PR TITLE
Set information criterion for NA distribution high

### DIFF
--- a/metasyn/distribution/na.py
+++ b/metasyn/distribution/na.py
@@ -30,3 +30,6 @@ class NADistribution(BaseDistribution):
     @classmethod
     def _param_schema(cls):
         return {}
+
+    def information_criterion(self, series):
+        return 1e10

--- a/metasyn/distribution/na.py
+++ b/metasyn/distribution/na.py
@@ -31,5 +31,5 @@ class NADistribution(BaseDistribution):
     def _param_schema(cls):
         return {}
 
-    def information_criterion(self, series):
+    def information_criterion(self, values):  # pylint: disable=unused-argument
         return 1e10


### PR DESCRIPTION
Not setting a high IC for the NA distribution causes the NA distribution to be selected for the disclosure control plugin (since there is not regex model). This PR should fix that.

There might be some more discussion to be had on the relative IC's for the static type of distributions, but I think for now, we should never select the NA distribution unless they're all NA's (or no other distributions are available).