### PR TITLE
Coverage

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -54,6 +54,9 @@ jobs:
         python -m pip install ".[test,extra]"
     - name: Test with pytest
       run: pytest tests
+    - name: Test coverage >= 95%
+      if: ${{ matrix.python-version == '3.12' }}
+      run: pytest --cov=metasyn tests/ --cov-report=term-missing --cov-fail-under=95
     - name: Check notebook output
       if: ${{ matrix.os != 'macos-latest' }}
       run: pytest --nbval-lax examples
@@ -70,9 +73,6 @@ jobs:
         metasyn schema -o current_schema.json
         MD5_DATA=(`md5sum current_schema.json`)
         [[ ${MD5_DATA[0]} == "c2a69330cec7a147ab775f5f0e037d8b" ]]
-    - name: Test coverage >= 95%
-      if: ${{ matrix.python-version == '3.12' }}
-      run: pytest --cov=metasyn tests/ --cov-report=term-missing --cov-fail-under=95
 
 
 

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -70,6 +70,9 @@ jobs:
         metasyn schema -o current_schema.json
         MD5_DATA=(`md5sum current_schema.json`)
         [[ ${MD5_DATA[0]} == "c2a69330cec7a147ab775f5f0e037d8b" ]]
+    - name: Test coverage >= 95%
+      if: ${{ matrix.python-version == '3.12' }}
+      run: pytest --cov=metasyn tests/ --cov-report=term-missing --cov-fail-under=95
 
 
 

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install ".[test,extra]"
+        python -m pip install -e ".[test,extra]"
     - name: Test with pytest
       run: pytest tests
     - name: Test coverage >= 95%

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -53,6 +53,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -e ".[test,extra]"
     - name: Test with pytest
+      if: ${{ matrix.python-version != '3.12' }}  # Either do coverage testing or pytest only
       run: pytest tests
     - name: Test coverage >= 95%
       if: ${{ matrix.python-version == '3.12' }}

--- a/metasyn/distribution/base.py
+++ b/metasyn/distribution/base.py
@@ -332,9 +332,10 @@ class UniqueDistributionMixin(BaseDistribution):
     variations, such as `UniqueFakerDistribution` and `UniqueRegexDistribution`.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.key_set: set = set()
+    def __new__(cls, *args, **kwargs):
+        instance = super().__new__(cls)
+        instance.key_set: set = set()
+        return instance
 
     def draw_reset(self):
         self.key_set = set()

--- a/metasyn/distribution/base.py
+++ b/metasyn/distribution/base.py
@@ -332,7 +332,7 @@ class UniqueDistributionMixin(BaseDistribution):
     variations, such as `UniqueFakerDistribution` and `UniqueRegexDistribution`.
     """
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs):  # noqa
         instance = super().__new__(cls)
         instance.key_set: set = set()
         return instance

--- a/metasyn/provider.py
+++ b/metasyn/provider.py
@@ -252,11 +252,14 @@ class DistributionProviderList():
             return dist_class(**dist_spec.parameters)
         except TypeError as err:
             dist_param = set(signature(dist_class.__init__).parameters) - {"self"}  # type: ignore
-            if "args" in dist_param or "kwargs" in dist_param:
-                raise err
             unknown_param = set(dist_spec.parameters) - dist_param  # type: ignore
+            missing_param = dist_param - set(dist_spec.parameters)
             if len(unknown_param) > 0:
-                raise TypeError(f"Unknown parameters {unknown_param} for variable {var_spec.name}.")
+                raise TypeError(f"Unknown parameters {unknown_param} for variable {var_spec.name}."
+                                f"Available parameters: {dist_param}")
+            if len(missing_param) > 0:
+                raise ValueError(f"Missing parameters for variable {var_spec.name}:"
+                                 f" {missing_param}.")
             raise err
 
     def _find_best_fit(self, series: pl.Series, var_type: str,

--- a/metasyn/provider.py
+++ b/metasyn/provider.py
@@ -253,7 +253,7 @@ class DistributionProviderList():
         except TypeError as err:
             dist_param = set(signature(dist_class.__init__).parameters) - {"self"}  # type: ignore
             unknown_param = set(dist_spec.parameters) - dist_param  # type: ignore
-            missing_param = dist_param - set(dist_spec.parameters)
+            missing_param = dist_param - set(dist_spec.parameters)  # type: ignore
             if len(unknown_param) > 0:
                 raise TypeError(f"Unknown parameters {unknown_param} for variable {var_spec.name}."
                                 f"Available parameters: {dist_param}")

--- a/metasyn/testutils.py
+++ b/metasyn/testutils.py
@@ -86,6 +86,10 @@ def check_distribution(distribution: type[BaseDistribution], privacy: BasePrivac
     assert isinstance(new_dist, distribution)
     assert set(list(new_dist.to_dict())) >= set(
         ("implements", "provenance", "class_name", "parameters"))
+    empty_series = pl.Series([], dtype=series.dtype)
+    new_dist = distribution.fit(empty_series, **privacy.fit_kwargs)
+    assert isinstance(new_dist, distribution)
+
 
 
 

--- a/metasyn/var.py
+++ b/metasyn/var.py
@@ -65,10 +65,6 @@ class MetaVar:
         if var_type is None:
             var_type = MetaVar.get_var_type(pl.Series([distribution.draw()]))
             distribution.draw_reset()
-            # if not isinstance(distribution.var_type, str):
-                # raise ValueError("Failed to infer variable type for variable '{name}'"
-                                #  " supply var_type or a different distribution.")
-            # var_type = distribution.var_type
         self.var_type = var_type
         self.distribution = distribution
         self.dtype = dtype

--- a/metasyn/var.py
+++ b/metasyn/var.py
@@ -88,9 +88,6 @@ class MetaVar:
     def get_var_type(series: pl.Series) -> str:
         """Convert polars dtype to metasyn variable type.
 
-        This method uses internal polars methods, so this might break at some
-        point.
-
         Parameters
         ----------
         series:

--- a/metasyn/var.py
+++ b/metasyn/var.py
@@ -63,10 +63,12 @@ class MetaVar:
     ):
         self.name = name
         if var_type is None:
-            if not isinstance(distribution.var_type, str):
-                raise ValueError("Failed to infer variable type for variable '{name}'"
-                                 " supply var_type or a different distribution.")
-            var_type = distribution.var_type
+            var_type = MetaVar.get_var_type(pl.Series([distribution.draw()]))
+            distribution.draw_reset()
+            # if not isinstance(distribution.var_type, str):
+                # raise ValueError("Failed to infer variable type for variable '{name}'"
+                                #  " supply var_type or a different distribution.")
+            # var_type = distribution.var_type
         self.var_type = var_type
         self.distribution = distribution
         self.dtype = dtype
@@ -130,7 +132,7 @@ class MetaVar:
         try:
             return convert_dict[polars_dtype]
         except KeyError as exc:
-            raise ValueError(f"Unsupported polars type '{polars_dtype}'") from exc
+            raise TypeError(f"Unsupported polars type '{polars_dtype}'") from exc
 
     def to_dict(self) -> Dict[str, Any]:
         """Create a dictionary from the variable."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,6 @@ max-locals=35
 
 [tool.ruff.lint.pydocstyle]
 convention="numpy"
+
+[tool.coverage.run]
+omit = ["metasyn/_version.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ documentation = "https://metasyn.readthedocs.io/en/latest/index.html"
 [project.optional-dependencies]
 extra = ["xlsxwriter", "pandas", "tomlkit"]
 check = ["ruff", "mypy", "types-tqdm", "types-regex"]
-test = ["pytest", "nbval"]
+test = ["pytest", "nbval", "pytest-cov"]
 docs = [
     "sphinx<9.0.0", "sphinx-rtd-theme", "sphinxcontrib-napoleon",
     "sphinx-autodoc-typehints", "sphinx_inline_tabs", "sphinx_copybutton",

--- a/tests/data/example_config.toml
+++ b/tests/data/example_config.toml
@@ -1,6 +1,7 @@
 # Example toml file as input for metasyn
 dist_providers = ["builtin"]
-
+config_version = "1.0"
+privacy = "none"
 
 [[var]]
 name = "PassengerId"

--- a/tests/data/incompatible_config.toml
+++ b/tests/data/incompatible_config.toml
@@ -1,0 +1,4 @@
+privacy = "disclosure"
+
+[defaults]
+privacy = "builtin"

--- a/tests/data/unsupported_config.toml
+++ b/tests/data/unsupported_config.toml
@@ -1,0 +1,1 @@
+config_version = "2.0"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,6 +75,8 @@ def test_meta_config_datafree():
 
 def test_meta_config():
     """Test the creation of a MetaConfig class that is not data free."""
+    with pytest.raises(ValueError):
+        MetaConfig.from_toml(Path("tests", "data", "titanic.csv"))
     meta_config = MetaConfig.from_toml(Path("tests", "data", "example_config.toml"))
     assert len(meta_config.var_specs) == 5
     var_spec = meta_config.get("Cabin")

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -1,9 +1,15 @@
 """Test the string type distribution inference."""
 import pandas as pd
 import polars as pl
+import pytest
 from pytest import mark
 
-from metasyn.distribution.string import FakerDistribution, FreeTextDistribution
+from metasyn.distribution.string import (
+    FakerDistribution,
+    FreeTextDistribution,
+    UniqueFakerDistribution,
+    UniqueRegexDistribution,
+)
 from metasyn.var import MetaVar
 
 
@@ -44,3 +50,21 @@ def test_free_text(series, lang, avg_sentences, avg_words):
     series_1 = var.draw_series(100, seed=1234)
     series_2 = var.draw_series(100, seed=1234)
     assert all(series_1 == series_2)
+
+
+def test_unique_regex():
+    dist = UniqueRegexDistribution(r"[0-9]")
+    var = MetaVar("some_var", "string", dist, prop_missing=0.0)
+
+    series = var.draw_series(10, None)
+    assert len(series.unique()) == 10
+
+    with pytest.raises(ValueError):
+        var.draw()
+
+def test_unique_faker():
+    dist = UniqueFakerDistribution("city")
+    var = MetaVar("some_var", "string", dist, prop_missing=0.0)
+
+    series = var.draw_series(1000, None)
+    assert len(series.unique()) == 1000

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -79,3 +79,9 @@ def test_toml_err():
 
     with pytest.raises(tomllib.TOMLDecodeError):
         MetaFrame.from_config(Path("tests", "data", "bad_config.toml"))
+
+    with pytest.raises(ValueError):
+        MetaFrame.from_config(Path("tests", "data", "unsupported_config.toml"))
+
+    with pytest.raises(ValueError):
+        MetaFrame.from_config(Path("tests", "data", "incompatible_config.toml"))

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -241,11 +241,11 @@ def test_invalid_prop(prop_missing):
         MetaVar("test", "discrete", DiscreteUniformDistribution.default_distribution(),
                 prop_missing=prop_missing)
 
-
 @mark.parametrize(
     "series,var_type",
     [
         (pl.Series([1, 2, 3]), "discrete"),
+        (pd.Series([1, 2, 3]), "discrete"),
         (pl.Series([1.0, 2.0, 3.0]), "continuous"),
         (pl.Series(["1", "2", "3"]), "string"),
         (pl.Series(["1", "2", "3"], dtype=pl.Categorical), "categorical"),
@@ -261,6 +261,13 @@ def test_invalid_prop(prop_missing):
 def test_get_var_type(series, var_type):
     """Test get_var_type method of MetaVar."""
     assert MetaVar.get_var_type(series) == var_type
+
+
+def test_unsupported_type():
+    series = pl.Series([MetaVar])
+    print(series.dtype)
+    with pytest.raises(TypeError):
+        MetaVar.get_var_type(series)
 
 
 @mark.parametrize(

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -265,7 +265,6 @@ def test_get_var_type(series, var_type):
 
 def test_unsupported_type():
     series = pl.Series([MetaVar])
-    print(series.dtype)
     with pytest.raises(TypeError):
         MetaVar.get_var_type(series)
 


### PR DESCRIPTION
- Add minimum 95% testing coverage (currently at 95.03%).
- Improved testing.
- Variable type can now be inferred from the distribution even if the distribution supports multiple variable types.
- `MetaVar.get_var_type` now returns a `TypeError` instead of a `ValueError` for unsupported types.
- A more appropriate error is thrown when a distribution is created with missing parameters.
- The `UniqueDistributionMixin` now implements `__new__` instead of `__init__`, so that the mixin does not cause the input parameters to change to *args, **kwargs. This should not have any effect on the user, except that the documentation and signature will now give the correct parameters for the unique faker and regex distributions.
