### PR TITLE
Improve performance of synthesization

### DIFF
--- a/docs/source/developer/distributions.rst
+++ b/docs/source/developer/distributions.rst
@@ -60,7 +60,9 @@ BaseDistribution class has a series of abstract methods that *must be* implemete
 
 If the distribution has subsequently draws that are not independent, it is recommended to implement :meth:`~metasyn.distribution.base.BaseDistribution.draw_reset`. As the name suggests, this method is intended to reset the distribution's drawing mechanism.
 
-It is recommended to also implement :meth:`~metasyn.distribution.base.BaseDistribution.information_criterion`. This is a class method used to determine which distribution gets selected during the fitting process for a series of values. The distribution with the lowest information criterion of the correct variable type will be selected. For discrete and continuous distributions it is currently implemented as `BIC <https://en.wikipedia.org/wiki/Bayesian_information_criterion>`_). 
+It is recommended to also implement :meth:`~metasyn.distribution.base.BaseDistribution.information_criterion`. This is a class method used to determine which distribution gets selected during the fitting process for a series of values. The distribution with the lowest information criterion of the correct variable type will be selected. For discrete and continuous distributions it is currently implemented as `BIC <https://en.wikipedia.org/wiki/Bayesian_information_criterion>`_. 
+
+Another optional method to implement is the :meth:`~metasyn.distribution.base.BaseDistribution.draw_list`. Normally, ``metasyn`` will draw values one at a time when synthesizing. Sometimes this is slow and it is faster to draw multiple values at once. In this case you can implement the :meth:`~metasyn.distribution.base.BaseDistribution.draw_list` method.
 
 There are more methods, but this is a good starting point when implementing a new distribution.
 For an overview of the rest of the methods and implementation details, refer to the :class:`~metasyn.distribution.base.BaseDistribution` class.

--- a/metasyn/distribution/base.py
+++ b/metasyn/distribution/base.py
@@ -189,10 +189,28 @@ class BaseDistribution(ABC):
 
     @classmethod
     @abstractmethod
-    def default_distribution(cls) -> BaseDistribution:
+    def default_distribution(cls) -> list:
         """Get a distribution with default parameters."""
         return cls()
 
+    def draw_series(self, n: int) -> pl.Series:
+        """Draw a series of values from the distribution.
+
+        Parameters
+        ----------
+        n:
+            Number of items to draw from the distribution.
+
+        Raises
+        ------
+        NotImplementedError:
+            If the distribution hasn't implemented a faster draw_series.
+
+        Returns
+        -------
+            List of values.
+        """
+        raise NotImplementedError()
 
 def metadist(
         implements: Optional[str] = None,
@@ -311,7 +329,7 @@ class ScipyDistribution(BaseDistribution):
             return int(val)
         return val
 
-    def draw_series(self, n):
+    def draw_series(self, n: int) -> pl.Series:
         values = self.dist.rvs(n)
         if self.var_type == "discrete":
             values = values.astype(np.int64)

--- a/metasyn/distribution/base.py
+++ b/metasyn/distribution/base.py
@@ -193,8 +193,8 @@ class BaseDistribution(ABC):
         """Get a distribution with default parameters."""
         return cls()
 
-    def draw_series(self, n: int) -> pl.Series:
-        """Draw a series of values from the distribution.
+    def draw_list(self, n: int) -> pl.Series:
+        """Draw a list of values from the distribution.
 
         Parameters
         ----------
@@ -204,7 +204,7 @@ class BaseDistribution(ABC):
         Raises
         ------
         NotImplementedError:
-            If the distribution hasn't implemented a faster draw_series.
+            If the distribution hasn't implemented a draw_list.
 
         Returns
         -------
@@ -329,7 +329,7 @@ class ScipyDistribution(BaseDistribution):
             return int(val)
         return val
 
-    def draw_series(self, n: int) -> pl.Series:
+    def draw_list(self, n: int) -> list:
         values = self.dist.rvs(n)
         if self.var_type == "discrete":
             values = values.astype(np.int64)

--- a/metasyn/distribution/base.py
+++ b/metasyn/distribution/base.py
@@ -306,7 +306,16 @@ class ScipyDistribution(BaseDistribution):
         return self.par
 
     def draw(self):
-        return self.dist.rvs()
+        val = self.dist.rvs()
+        if self.var_type == "discrete":
+            return int(val)
+        return val
+
+    def draw_series(self, n):
+        values = self.dist.rvs(n)
+        if self.var_type == "discrete":
+            values = values.astype(np.int64)
+        return list(values)
 
     def information_criterion(self, values):
         vals = self._to_series(values)

--- a/metasyn/distribution/base.py
+++ b/metasyn/distribution/base.py
@@ -189,11 +189,11 @@ class BaseDistribution(ABC):
 
     @classmethod
     @abstractmethod
-    def default_distribution(cls) -> list:
+    def default_distribution(cls) -> BaseDistribution:
         """Get a distribution with default parameters."""
         return cls()
 
-    def draw_list(self, n: int) -> pl.Series:
+    def draw_list(self, n: int) -> list:
         """Draw a list of values from the distribution.
 
         Parameters

--- a/metasyn/var.py
+++ b/metasyn/var.py
@@ -254,7 +254,7 @@ class MetaVar:
         is_not_na = np.random.rand(n) >= self.prop_missing
         n_draw = np.sum(is_not_na)
         try:
-            not_na_values = self.distribution.draw_series(n_draw)
+            not_na_values = self.distribution.draw_list(n_draw)
         except NotImplementedError:
             not_na_values = [self.distribution.draw()
                              for _ in tqdm(range(n_draw), disable=not progress_bar, leave=False,

--- a/metasyn/var.py
+++ b/metasyn/var.py
@@ -252,7 +252,7 @@ class MetaVar:
         self.distribution.draw_reset()
 
         is_not_na = np.random.rand(n) >= self.prop_missing
-        n_draw = np.sum(is_not_na)
+        n_draw: int = np.sum(is_not_na)  # type: ignore
         try:
             not_na_values = self.distribution.draw_list(n_draw)
         except NotImplementedError:


### PR DESCRIPTION
While we're getting worried about synthesizing and how long that takes, we might as well implement vectorization for the Scipy distributions.

Takes the test dataset with 10K rows from ~20 seconds to ~8 seconds.

TODO:

- [x] Refactor base class to add `draw_series`, + raise NotImplementedError if not implemented.
- [x] Improve performance of adding None's
- [x] Tests
- [x] Developer documentation update