### PR TITLE
Add distribution module to exports for type completion

### DIFF
--- a/metasyn/__init__.py
+++ b/metasyn/__init__.py
@@ -20,25 +20,42 @@ generated synthetic data.
 
 from importlib.metadata import version
 
+from metasyn import distribution
 from metasyn.demo.dataset import demo_dataframe, demo_file
 from metasyn.distribution.base import metadist
 from metasyn.file import (
-           read_csv,
-           read_dta,
-           read_excel,
-           read_sav,
-           read_tsv,
-           write_csv,
-           write_dta,
-           write_excel,
-           write_sav,
-           write_tsv,
+    read_csv,
+    read_dta,
+    read_excel,
+    read_sav,
+    read_tsv,
+    write_csv,
+    write_dta,
+    write_excel,
+    write_sav,
+    write_tsv,
 )
 from metasyn.metaframe import MetaFrame
 from metasyn.var import MetaVar
 from metasyn.varspec import VarSpec
 
-__all__ = ["MetaVar", "MetaFrame", "demo_file", "demo_dataframe", "metadist", "VarSpec",
-           "read_csv", "read_sav", "read_tsv", "read_excel", "read_dta",
-           "write_csv", "write_dta", "write_excel", "write_sav", "write_tsv"]
+__all__ = [
+    "MetaVar",
+    "MetaFrame",
+    "demo_file",
+    "demo_dataframe",
+    "metadist",
+    "VarSpec",
+    "read_csv",
+    "read_sav",
+    "read_tsv",
+    "read_excel",
+    "read_dta",
+    "write_csv",
+    "write_dta",
+    "write_excel",
+    "write_sav",
+    "write_tsv",
+    "distribution",
+]
 __version__ = version("metasyn")

--- a/metasyn/__init__.py
+++ b/metasyn/__init__.py
@@ -20,7 +20,7 @@ generated synthetic data.
 
 from importlib.metadata import version
 
-from metasyn import distribution, privacy
+from metasyn import distribution, file, privacy
 from metasyn.demo.dataset import demo_dataframe, demo_file
 from metasyn.distribution.base import metadist
 from metasyn.file import (
@@ -57,6 +57,7 @@ __all__ = [
     "write_sav",
     "write_tsv",
     "distribution",
+    "file",
     "privacy",
 ]
 __version__ = version("metasyn")

--- a/metasyn/__init__.py
+++ b/metasyn/__init__.py
@@ -20,7 +20,7 @@ generated synthetic data.
 
 from importlib.metadata import version
 
-from metasyn import distribution
+from metasyn import distribution, privacy
 from metasyn.demo.dataset import demo_dataframe, demo_file
 from metasyn.distribution.base import metadist
 from metasyn.file import (
@@ -57,5 +57,6 @@ __all__ = [
     "write_sav",
     "write_tsv",
     "distribution",
+    "privacy",
 ]
 __version__ = version("metasyn")


### PR DESCRIPTION
We often use `metasyn.distribution` when we actually create synthetic data. This change enables type completion and avoids `AttributeError`s from type checkers when doing the following:

```py
import metasyn as ms
ms.distribution.RegexDistribution("[0-5]{10}").draw()
```

It's a small improvement in quality of life :)