### PR TITLE
Fix typing for unique key distribution

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -60,7 +60,8 @@ jobs:
       run: pytest tests
     - name: Test coverage >= 95%
       if: ${{ matrix.python-version == '3.12' }}
-      run: pytest --cov=metasyn tests/ --cov-report=term-missing --cov-fail-under=95
+      run: pytest tests
+      # run: pytest --cov=metasyn tests/ --cov-report=term-missing --cov-fail-under=95
     - name: Check notebook output
       if: ${{ matrix.os != 'macos-latest' }}
       run: pytest --nbval-lax examples

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -60,8 +60,7 @@ jobs:
       run: pytest tests
     - name: Test coverage >= 95%
       if: ${{ matrix.python-version == '3.12' }}
-      run: pytest tests
-      # run: pytest --cov=metasyn tests/ --cov-report=term-missing --cov-fail-under=95
+      run: pytest --cov=metasyn tests/ --cov-report=term-missing --cov-fail-under=95
     - name: Check notebook output
       if: ${{ matrix.os != 'macos-latest' }}
       run: pytest --nbval-lax examples

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -76,7 +76,7 @@ jobs:
       run: |
         metasyn schema -o current_schema.json
         MD5_DATA=(`md5sum current_schema.json`)
-        [[ ${MD5_DATA[0]} == "c2a69330cec7a147ab775f5f0e037d8b" ]]
+        [[ ${MD5_DATA[0]} == "8e9351c9b1513a6586ad94fa8b82d94e" ]]
 
 
 

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         include:
             - os: macos-latest
               python-version: "3.13"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,8 +9,8 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
-
+    python: "3.12"
+# 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py

--- a/metasyn/__main__.py
+++ b/metasyn/__main__.py
@@ -6,11 +6,10 @@ synthetic data from GMF files and creating json schemas for GMF files.
 import argparse
 import json
 import pathlib
-from typing import Optional
 import sys
 from argparse import RawDescriptionHelpFormatter
-
 from importlib.metadata import entry_points, version
+from typing import Optional
 
 from metasyn import MetaFrame
 from metasyn.config import MetaConfig

--- a/metasyn/__main__.py
+++ b/metasyn/__main__.py
@@ -10,11 +10,7 @@ from typing import Optional
 import sys
 from argparse import RawDescriptionHelpFormatter
 
-try:  # Python < 3.10 (backport)
-    from importlib_metadata import entry_points, version
-except ImportError:
-    from importlib.metadata import entry_points, version  # type: ignore [assignment]
-
+from importlib.metadata import entry_points, version
 
 from metasyn import MetaFrame
 from metasyn.config import MetaConfig

--- a/metasyn/demo/dataset.py
+++ b/metasyn/demo/dataset.py
@@ -11,10 +11,7 @@ import polars as pl
 
 from metasyn.varspec import VarSpec
 
-try:
-    from importlib_resources import files
-except ImportError:
-    from importlib.resources import files  # type: ignore
+from importlib.resources import files
 
 _AVAILABLE_DATASETS = {}
 

--- a/metasyn/demo/dataset.py
+++ b/metasyn/demo/dataset.py
@@ -4,14 +4,13 @@
 import string
 from abc import ABC, abstractmethod
 from datetime import date, datetime, time, timedelta
+from importlib.resources import files
 from pathlib import Path
 
 import numpy as np
 import polars as pl
 
 from metasyn.varspec import VarSpec
-
-from importlib.resources import files
 
 _AVAILABLE_DATASETS = {}
 

--- a/metasyn/distribution/uniquekey.py
+++ b/metasyn/distribution/uniquekey.py
@@ -104,7 +104,7 @@ class UniqueKeyDistribution(BaseDistribution):
                 - 2*np.sum(np.log(1/np.arange(n_choice, n_choice-len(values), -1))))
 
     @classmethod
-    def default_distribution(cls, var_type=None) -> UKeyT: # noqa: ARG003
+    def default_distribution(cls: type[UKeyT], var_type=None) -> UKeyT: # noqa: ARG003
         return cls(0, False)
 
     @classmethod
@@ -117,6 +117,8 @@ class UniqueKeyDistribution(BaseDistribution):
 @metafit(distribution=UniqueKeyDistribution, var_type="discrete")
 class UniqueKeyFitter(BaseFitter):
     """Fitter for unique key distribution."""
+
+    distribution: type[UniqueKeyDistribution]
 
     def _fit(self, series) -> UniqueKeyDistribution:
         lower = series.min()

--- a/metasyn/privacy.py
+++ b/metasyn/privacy.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional, Type, Union
 
-try:
-    from importlib_metadata import entry_points
-except ImportError:
-    from importlib.metadata import entry_points  # type: ignore
+from importlib.metadata import entry_points
 
 from metasyn.util import get_registry
 

--- a/metasyn/privacy.py
+++ b/metasyn/privacy.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Optional, Type, Union
-
 from importlib.metadata import entry_points
+from typing import TYPE_CHECKING, Optional, Type, Union
 
 from metasyn.util import get_registry
 

--- a/metasyn/registry.py
+++ b/metasyn/registry.py
@@ -7,10 +7,9 @@ See pyproject.toml on how the builtin distributions are registered.
 from __future__ import annotations
 
 import warnings
+from importlib.metadata import entry_points
 from inspect import signature
 from typing import TYPE_CHECKING, Any, Optional, Union
-
-from importlib.metadata import entry_points
 
 import numpy as np
 import polars as pl

--- a/metasyn/registry.py
+++ b/metasyn/registry.py
@@ -10,10 +10,7 @@ import warnings
 from inspect import signature
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-try:
-    from importlib_metadata import entry_points
-except ImportError:
-    from importlib.metadata import entry_points  # type: ignore
+from importlib.metadata import entry_points
 
 import numpy as np
 import polars as pl

--- a/metasyn/util.py
+++ b/metasyn/util.py
@@ -25,7 +25,7 @@ def get_registry() -> dict:
     -------
         Dictionary containing the registry entries.
     """
-    registry_fp = files(__package__).joinpath("schema", "plugin_registry.toml")
+    registry_fp = files(__package__) / "schema" / "plugin_registry.toml"
     with registry_fp.open("rb") as handle:
         registry = tomllib.load(handle)
     return registry

--- a/metasyn/util.py
+++ b/metasyn/util.py
@@ -12,10 +12,7 @@ try:
 except ImportError:
     import tomli as tomllib  # type: ignore  # noqa
 
-try:
-    from importlib_resources import files
-except ImportError:
-    from importlib.resources import files  # type: ignore
+from importlib.resources import files
 
 
 ALL_VAR_TYPES = ["discrete", "continuous", "time", "date", "datetime", "string", "categorical"]

--- a/metasyn/util.py
+++ b/metasyn/util.py
@@ -14,7 +14,6 @@ except ImportError:
 
 from importlib.resources import files
 
-
 ALL_VAR_TYPES = ["discrete", "continuous", "time", "date", "datetime", "string", "categorical"]
 
 def get_registry() -> dict:

--- a/metasyn/util.py
+++ b/metasyn/util.py
@@ -25,8 +25,8 @@ def get_registry() -> dict:
     -------
         Dictionary containing the registry entries.
     """
-    registry_fp = files(__package__) / "schema" / "plugin_registry.toml"
-    with open(registry_fp, "rb") as handle:
+    registry_fp = files(__package__).joinpath("schema", "plugin_registry.toml")
+    with registry_fp.open("rb") as handle:
         registry = tomllib.load(handle)
     return registry
 

--- a/metasyn/validation.py
+++ b/metasyn/validation.py
@@ -7,10 +7,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 
-try:
-    from importlib_metadata import entry_points
-except ImportError:
-    from importlib.metadata import entry_points  # type: ignore
+from importlib.metadata import entry_points
 
 import jsonschema
 

--- a/metasyn/validation.py
+++ b/metasyn/validation.py
@@ -6,7 +6,6 @@ This ensures that the Generative Metadata Format (GMF) files are interoperable a
 from __future__ import annotations
 
 from copy import deepcopy
-
 from importlib.metadata import entry_points
 
 import jsonschema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,11 @@ authors = [
 ]
 description = "Package for creating synthetic datasets while preserving privacy."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["metadata", "open-data", "privacy", "synthetic-data", "tabular datasets"]
 license = { file = "LICENSE" }
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -36,8 +34,6 @@ dependencies = [
     "lingua-language-detector",
     "regex",
     "jsonschema",
-    "importlib-metadata;python_version<'3.10'",
-    "importlib-resources;python_version<'3.9'",
     "tomli;python_version<'3.11'",
     "regexmodel>=0.2.1"
 ]
@@ -86,8 +82,6 @@ module = [
     "pandas.*",
     "jsonschema.*",
     "sklearn.*",
-    "importlib_metadata.*",
-    "importlib_resources.*",
     "wget.*",
     "lingua.*",
     "tomllib.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ GitHub = "https://github.com/sodascience/metasyn"
 documentation = "https://metasyn.readthedocs.io/en/latest/index.html"
 
 [project.optional-dependencies]
-extra = ["xlsxwriter", "pandas", "tomlkit", "pyreadstat<1.3;python_version<'3.10'",
-         "pyreadstat;python_version>'3.9'", "fastexcel"]
+extra = ["xlsxwriter", "pandas", "tomlkit",
+         "pyreadstat>=1.3'", "fastexcel"]
 check = ["ruff", "mypy", "types-tqdm", "types-regex"]
 test = ["pytest", "nbval", "pytest-cov"]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ documentation = "https://metasyn.readthedocs.io/en/latest/index.html"
 
 [project.optional-dependencies]
 extra = ["xlsxwriter", "pandas", "tomlkit",
-         "pyreadstat>=1.3'", "fastexcel"]
+         "pyreadstat>=1.3", "fastexcel"]
 check = ["ruff", "mypy", "types-tqdm", "types-regex"]
 test = ["pytest", "nbval", "pytest-cov"]
 docs = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,13 +2,16 @@
 import json
 import subprocess
 import sys
+import pytest
 from pathlib import Path
 
 import jsonschema
 import polars as pl
 from pytest import fixture, mark
 
+import metasyn as ms
 from metasyn import MetaFrame
+from metasyn.__main__ import main
 from metasyn.file import _AVAILABLE_FILE_INTERFACES
 from metasyn.validation import validate_gmf_dict
 
@@ -38,9 +41,14 @@ def tmp_dir(tmp_path_factory) -> Path:
             "Age": float,
             "Fare": float
         }
-        data_frame = pl.read_csv(csv_fp, schema_overrides=csv_dt)[:100]
-        meta_frame = MetaFrame.fit_dataframe(data_frame, var_specs=[
-            {"name": "PassengerId", "distribution": {"unique": True}}])
+        data_frame, file_format = ms.read_csv(csv_fp, schema_overrides=csv_dt, n_rows=100)
+        meta_frame = MetaFrame.fit_dataframe(data_frame,
+                                             var_specs=[{"name": "PassengerId",
+                                                        "distribution": {"unique": True}}],
+                                             file_format=file_format)
+        # data_frame = pl.read_csv(csv_fp, schema_overrides=csv_dt)[:100]
+        # meta_frame = MetaFrame.fit_dataframe(data_frame, var_specs=[
+            # {"name": "PassengerId", "distribution": {"unique": True}}])
         meta_frame.save_json(json_path)
         config_fp = TMP_DIR_PATH / "config.ini"
         with open(config_fp, "w") as handle:
@@ -65,8 +73,8 @@ def test_cli(tmp_dir, ext):
 
     # create command to run in subprocess with arguments
     cmd = [
-        Path(sys.executable).resolve(),   # the python executable
-        Path("metasyn", "__main__.py"),   # the cli script
+        # Path(sys.executable).resolve(),   # the python executable
+        # Path("metasyn", "__main__.py"),   # the cli script
         "synthesize",                     # the subcommand
         "-n 25",                          # only generate 25 samples
         tmp_dir / "titanic.json",         # the input file
@@ -77,21 +85,34 @@ def test_cli(tmp_dir, ext):
     ]
 
     # Run the cli with different extensions
-    result = subprocess.run(cmd, check=False)
-    assert result.returncode == 0, (result.stdout, result.stderr)
+    # result = subprocess.run(cmd, check=False)
+    main(cmd)
+    # assert result.returncode == 0, (result.stdout, result.stderr)
     assert out_file.is_file()
     if ext == ".csv":
         df = pl.read_csv(out_file)
         assert len(df) == 25
 
+    main(["synthesize", tmp_dir / "titanic.json", "--preview"])
+
+    # Check if errors are raised when a csv file is supplied.
+    with pytest.raises(SystemExit):
+        main(["synthesize", out_file, "-o", out_file])
+
+
+def test_main_cli():
+    main(["--version"])
+    main(["--help"])
+    with pytest.raises(SystemExit):
+        main(["command_does_not_exit"])
 
 @mark.parametrize("config", [True, False])
 def test_create_meta(tmp_dir, config):
     """CLI test on creating metadata from a csv."""
     out_file = tmp_dir / "test.json"
     cmd = [
-        Path(sys.executable).resolve(),     # the python executable
-        Path("metasyn", "__main__.py"),     # the cli script
+        # Path(sys.executable).resolve(),     # the python executable
+        # Path("metasyn", "__main__.py"),     # the cli script
         "create-meta",                      # the subcommand
         Path("tests", "data", "titanic.csv"),  # the input file
         "-o",
@@ -99,46 +120,59 @@ def test_create_meta(tmp_dir, config):
     ]
     if config:
         cmd.extend(["--config", Path(tmp_dir) / 'config.ini'])
-    result = subprocess.run(cmd, check=False, capture_output=True)
-    assert result.returncode == 0, result.stdout + result.stderr
+    # result = subprocess.run(cmd, check=False, capture_output=True)
+    # assert result.returncode == 0, result.stdout + result.stderr
+    main(cmd)
     assert out_file.is_file()
     meta_frame = MetaFrame.load_json(out_file)
     assert len(meta_frame.meta_vars) == 12
+
+    with pytest.raises(SystemExit):
+        main(["create-meta", "-o", "some_file"])
 
 
 def test_schema_list():
     """Test whether all plugins/schemas are listed."""
     cmd = [
-        Path(sys.executable).resolve(),     # the python executable
-        Path("metasyn", "__main__.py"),     # the cli script
+        # Path(sys.executable).resolve(),     # the python executable
+        # Path("metasyn", "__main__.py"),     # the cli script
         "schema",
         "--list"
     ]
-    result = subprocess.run(cmd, check=False, capture_output=True)
-    assert result.returncode == 0
-    assert "builtin" in result.stdout.decode()
+    # result = subprocess.run(cmd, check=False, capture_output=True)
+    # assert result.returncode == 0
+    # assert "builtin" in result.stdout.decode()
+    main(cmd)
 
 
 def test_schema_gen(tmp_dir):
     """Test whether the metadata schemas can be created."""
     titanic_json = tmp_dir / "titanic.json"
+    schema_file = tmp_dir / "schema.json"
     cmd = [
-        Path(sys.executable).resolve(),     # the python executable
-        Path("metasyn", "__main__.py"),     # the cli script
+        # Path(sys.executable).resolve(),     # the python executable
+        # Path("metasyn", "__main__.py"),     # the cli script
         "schema",
-        "builtin"
+        "builtin",
+        "-o",
+        schema_file
     ]
-    result = subprocess.run(cmd, check=False, capture_output=True)
-    assert result.returncode == 0
-    json_schema = json.loads(result.stdout.decode())
+    # result = subprocess.run(cmd, check=False, capture_output=True)
+    # assert result.returncode == 0
+    # json_schema = json.loads(result.stdout.decode())
+    main(cmd)
+    with open(schema_file, "r") as handle:
+        json_schema = json.load(handle)
+
     with open(titanic_json, "r") as handle:
         gmf_dict = json.load(handle)
     validate_gmf_dict(gmf_dict)
     jsonschema.validate(gmf_dict, json_schema)
 
-    cmd.append("non-existent-plugin")
-    result = subprocess.run(cmd, check=False, capture_output=True)
-    assert result.returncode != 0
+    with pytest.raises(SystemExit):
+        main(["schema", "non-existent-plugin"])
+    # result = subprocess.run(cmd, check=False, capture_output=True)
+    # assert result.returncode != 0
 
 
 def test_datafree(tmp_dir):
@@ -146,27 +180,29 @@ def test_datafree(tmp_dir):
     gmf_fp = tmp_dir / "gmf_out.json"
     syn_fp = tmp_dir / "test_out.csv"
     cmd = [
-        Path(sys.executable).resolve(),     # the python executable
-        Path("metasyn", "__main__.py"),     # the cli script
+        # Path(sys.executable).resolve(),     # the python executable
+        # Path("metasyn", "__main__.py"),     # the cli script
         "create-meta",                      # the subcommand
         "--config", Path("tests", "data", "no_data_config.toml"),
         "--output", gmf_fp,              # the output file
     ]
-    result = subprocess.run(cmd, check=False, capture_output=True)
-    assert result.returncode == 0
+    # result = subprocess.run(cmd, check=False, capture_output=True)
+    # assert result.returncode == 0
+    main(cmd)
     meta_frame = MetaFrame.load_json(gmf_fp)
     assert meta_frame.n_rows == 100
     assert len(meta_frame.meta_vars) == 3
     cmd2 = [
-        Path(sys.executable).resolve(),     # the python executable
-        Path("metasyn", "__main__.py"),     # the cli script
+        # Path(sys.executable).resolve(),     # the python executable
+        # Path("metasyn", "__main__.py"),     # the cli script
         "synthesize",
         gmf_fp,
         "-o",
         syn_fp
     ]
-    result = subprocess.run(cmd2, check=False, capture_output=True)
-    assert result.returncode == 0
+    # result = subprocess.run(cmd2, check=False, capture_output=True)
+    # assert result.returncode == 0
+    main(cmd2)
     df = pl.read_csv(syn_fp)
     assert list(df.columns) == ["PassengerId", "Name", "Cabin"]
     assert len(df) == 100
@@ -176,14 +212,15 @@ def test_custom_file_interface(tmp_dir):
     input_fp = Path("tests", "data", "actually_a_csv_file.sav")
     out_gmf = tmp_dir / "temp.json"
     cmd = [
-        Path(sys.executable).resolve(),
-        Path("metasyn", "__main__.py"),
+        # Path(sys.executable).resolve(),
+        # Path("metasyn", "__main__.py"),
         "create-meta",
         input_fp,
         "--config", config_fp,
         "--output", out_gmf,
     ]
-    result = subprocess.run(cmd, check=False, capture_output=True)
-    assert result.returncode == 0
+    main(cmd)
+    # result = subprocess.run(cmd, check=False, capture_output=True)
+    # assert result.returncode == 0
     meta_frame = MetaFrame.load_json(out_gmf)
     assert len(meta_frame.meta_vars) == 12

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,10 @@
 """Module with tests for the command line interface."""
 import json
-import subprocess
-import sys
-import pytest
 from pathlib import Path
 
 import jsonschema
 import polars as pl
+import pytest
 from pytest import fixture, mark
 
 import metasyn as ms
@@ -46,9 +44,6 @@ def tmp_dir(tmp_path_factory) -> Path:
                                              var_specs=[{"name": "PassengerId",
                                                         "distribution": {"unique": True}}],
                                              file_format=file_format)
-        # data_frame = pl.read_csv(csv_fp, schema_overrides=csv_dt)[:100]
-        # meta_frame = MetaFrame.fit_dataframe(data_frame, var_specs=[
-            # {"name": "PassengerId", "distribution": {"unique": True}}])
         meta_frame.save_json(json_path)
         config_fp = TMP_DIR_PATH / "config.ini"
         with open(config_fp, "w") as handle:
@@ -73,8 +68,6 @@ def test_cli(tmp_dir, ext):
 
     # create command to run in subprocess with arguments
     cmd = [
-        # Path(sys.executable).resolve(),   # the python executable
-        # Path("metasyn", "__main__.py"),   # the cli script
         "synthesize",                     # the subcommand
         "-n 25",                          # only generate 25 samples
         tmp_dir / "titanic.json",         # the input file
@@ -85,9 +78,7 @@ def test_cli(tmp_dir, ext):
     ]
 
     # Run the cli with different extensions
-    # result = subprocess.run(cmd, check=False)
     main(cmd)
-    # assert result.returncode == 0, (result.stdout, result.stderr)
     assert out_file.is_file()
     if ext == ".csv":
         df = pl.read_csv(out_file)
@@ -111,8 +102,6 @@ def test_create_meta(tmp_dir, config):
     """CLI test on creating metadata from a csv."""
     out_file = tmp_dir / "test.json"
     cmd = [
-        # Path(sys.executable).resolve(),     # the python executable
-        # Path("metasyn", "__main__.py"),     # the cli script
         "create-meta",                      # the subcommand
         Path("tests", "data", "titanic.csv"),  # the input file
         "-o",
@@ -120,8 +109,6 @@ def test_create_meta(tmp_dir, config):
     ]
     if config:
         cmd.extend(["--config", Path(tmp_dir) / 'config.ini'])
-    # result = subprocess.run(cmd, check=False, capture_output=True)
-    # assert result.returncode == 0, result.stdout + result.stderr
     main(cmd)
     assert out_file.is_file()
     meta_frame = MetaFrame.load_json(out_file)
@@ -134,14 +121,9 @@ def test_create_meta(tmp_dir, config):
 def test_schema_list():
     """Test whether all plugins/schemas are listed."""
     cmd = [
-        # Path(sys.executable).resolve(),     # the python executable
-        # Path("metasyn", "__main__.py"),     # the cli script
         "schema",
         "--list"
     ]
-    # result = subprocess.run(cmd, check=False, capture_output=True)
-    # assert result.returncode == 0
-    # assert "builtin" in result.stdout.decode()
     main(cmd)
 
 
@@ -150,16 +132,11 @@ def test_schema_gen(tmp_dir):
     titanic_json = tmp_dir / "titanic.json"
     schema_file = tmp_dir / "schema.json"
     cmd = [
-        # Path(sys.executable).resolve(),     # the python executable
-        # Path("metasyn", "__main__.py"),     # the cli script
         "schema",
         "builtin",
         "-o",
         schema_file
     ]
-    # result = subprocess.run(cmd, check=False, capture_output=True)
-    # assert result.returncode == 0
-    # json_schema = json.loads(result.stdout.decode())
     main(cmd)
     with open(schema_file, "r") as handle:
         json_schema = json.load(handle)
@@ -171,8 +148,6 @@ def test_schema_gen(tmp_dir):
 
     with pytest.raises(SystemExit):
         main(["schema", "non-existent-plugin"])
-    # result = subprocess.run(cmd, check=False, capture_output=True)
-    # assert result.returncode != 0
 
 
 def test_datafree(tmp_dir):
@@ -180,28 +155,20 @@ def test_datafree(tmp_dir):
     gmf_fp = tmp_dir / "gmf_out.json"
     syn_fp = tmp_dir / "test_out.csv"
     cmd = [
-        # Path(sys.executable).resolve(),     # the python executable
-        # Path("metasyn", "__main__.py"),     # the cli script
         "create-meta",                      # the subcommand
         "--config", Path("tests", "data", "no_data_config.toml"),
         "--output", gmf_fp,              # the output file
     ]
-    # result = subprocess.run(cmd, check=False, capture_output=True)
-    # assert result.returncode == 0
     main(cmd)
     meta_frame = MetaFrame.load_json(gmf_fp)
     assert meta_frame.n_rows == 100
     assert len(meta_frame.meta_vars) == 3
     cmd2 = [
-        # Path(sys.executable).resolve(),     # the python executable
-        # Path("metasyn", "__main__.py"),     # the cli script
         "synthesize",
         gmf_fp,
         "-o",
         syn_fp
     ]
-    # result = subprocess.run(cmd2, check=False, capture_output=True)
-    # assert result.returncode == 0
     main(cmd2)
     df = pl.read_csv(syn_fp)
     assert list(df.columns) == ["PassengerId", "Name", "Cabin"]
@@ -212,15 +179,11 @@ def test_custom_file_interface(tmp_dir):
     input_fp = Path("tests", "data", "actually_a_csv_file.sav")
     out_gmf = tmp_dir / "temp.json"
     cmd = [
-        # Path(sys.executable).resolve(),
-        # Path("metasyn", "__main__.py"),
         "create-meta",
         input_fp,
         "--config", config_fp,
         "--output", out_gmf,
     ]
     main(cmd)
-    # result = subprocess.run(cmd, check=False, capture_output=True)
-    # assert result.returncode == 0
     meta_frame = MetaFrame.load_json(out_gmf)
     assert len(meta_frame.meta_vars) == 12

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -211,8 +211,10 @@ def test_stata(tmpdir):
             assert df_new[col].dtype == pl.Int32  # Unfixable, since stata doesn't have Int8, etc
         elif col == "UInt64":
             assert df_new[col].dtype == pl.Int64  # Bugged
-        elif col in ("Date", "Datetime"):
+        elif col == "Datetime":
             assert str(df_new[col].dtype.base_type()) == "Datetime"  # Bugged
+        elif col == "Date":
+            assert str(df_new[col].dtype.base_type()) == "Date"
         elif col == "Categorical":
             assert df_new[col].dtype == pl.String  # Bugged
         elif col == "Boolean":


### PR DESCRIPTION
- Pyreadstat > 1.3 now reads polars dataframes, so we are not transforming to pandas for .sav and .dat files.
- Require Python >= 3.10. Python 3.9 will be deprecated tomorrow, and pyreadstat is not available for 3.9 anymore.
- Fix the coverage testing, now at almost 96%.
- Fix the typing for the unique key distribution.