### PR TITLE
Add option to prefix columns and file names

### DIFF
--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -164,6 +164,15 @@ If you used :func:`metasyn.read_csv` to read in your file and added the file for
 
    mf.write_synthetic("some_file_name.csv")
 
+It can be useful to create a synthetic dataset where it is more clear that the data is synthetic. You can do this by giving a column prefix or a file prefix:
+
+.. code-block:: python
+
+   mf.write_synthetic(column_prefix="synthetic_", file_prefix="SYN_")
+
+
+This will result in columns that are named synthetic_PassengerId, synthetic_name, ... and the filename SYN_titanic.csv.
+
 Conclusion
 ----------
 

--- a/metasyn/__main__.py
+++ b/metasyn/__main__.py
@@ -197,12 +197,26 @@ Example: {EXAMPLE_SYNTHESIZE}
         help="preview six-row synthesized data frame in console and exit",
         action="store_true",
     )
+    parser.add_argument(
+        "-c", "--column-prefix",
+        help="Prefix the columns of the dataset. For example, if the prefix is SYNTHETIC_, then "
+        "column id will become SYNTHETIC_id.",
+        default="",
+        required=False,
+    )
+    parser.add_argument(
+        "-f", "--file-prefix",
+        help="Prefix the filename. For example if the prefix is syn_, then a test.csv will become "
+        "syn_test.csv.",
+        default="",
+        required=False,
+    )
 
     # parse the args without the subcommand
-    args, _ = parser.parse_known_args(input_args)
+    args = parser.parse_args(input_args)
 
-    if not args.preview and not args.output:
-        parser.error("Output file is required if you are not using the preview option.")
+    # if not args.preview and not args.output:
+        # parser.error("Output file is required if you are not using the preview option.")
 
     # Create the metaframe from the GMF file
     try:
@@ -225,14 +239,16 @@ Example: {EXAMPLE_SYNTHESIZE}
     # Store the dataframe to file
     if meta_frame.file_format is not None:
         file_interface = file_interface_from_dict(meta_frame.file_format)
-        if args.output.suffix not in file_interface.extensions:
+        if args.output is not None and args.output.suffix not in file_interface.extensions:
             file_interface = get_file_interface_class(args.output).default_interface(args.output)
         meta_frame.write_synthetic(args.output, n=args.num_rows, seed=args.seed,
-                                   file_format=file_interface)
+                                   file_format=file_interface, column_prefix=args.column_prefix,
+                                   file_prefix=args.file_prefix)
     else:
         file_interface = get_file_interface_class(args.output).default_interface(args.output)
         meta_frame.write_synthetic(args.output, n=args.num_rows, seed=args.seed,
-                                   file_format=file_interface)
+                                   file_format=file_interface, column_prefix=args.column_prefix,
+                                   file_prefix=args.file_prefix)
 
 
 def schema(input_args) -> None:

--- a/metasyn/file.py
+++ b/metasyn/file.py
@@ -86,7 +86,7 @@ class BaseFileInterface(ABC):
         raise NotImplementedError("Write synthetic is not implemented for the BaseFileInterface.")
 
     def write_file(self, df: pl.DataFrame, fp: Union[None, Path, str] = None,
-                        overwrite: bool = False):
+                        overwrite: bool = False, file_prefix: str = ""):
         """Write the synthetic dataframe to a file.
 
         Parameters
@@ -105,11 +105,12 @@ class BaseFileInterface(ABC):
         FileExistsError
             If the file already exists and the overwrite argument is False.
         """
-        fp = self.check_filename(fp, overwrite=overwrite)
+        fp = self.check_filename(fp, overwrite=overwrite, file_prefix=file_prefix)
         self._write_file(df, fp)
 
     def check_filename(self,  fp: Union[None, Path, str] = None,
-                        overwrite: bool = False) -> Union[Path, str]:
+                        overwrite: bool = False,
+                        file_prefix: str = "") -> Union[Path, str]:
         """Check whether the filename can be written to.
 
         Parameters
@@ -131,7 +132,7 @@ class BaseFileInterface(ABC):
             If the parent directory of fp does not exist.
         """
         if fp is None:
-            fp = self.file_name
+            fp = file_prefix + self.file_name
         if Path(fp).is_file() and not overwrite:
             raise FileExistsError(f"File '{fp}' already exists, choose a different name or write "
                                   "to a different directory.")

--- a/metasyn/file.py
+++ b/metasyn/file.py
@@ -110,7 +110,7 @@ class BaseFileInterface(ABC):
 
     def check_filename(self,  fp: Union[None, Path, str] = None,
                         overwrite: bool = False,
-                        file_prefix: str = "") -> Union[Path, str]:
+                        file_prefix: str = "") -> Path:
         """Check whether the filename can be written to.
 
         Parameters
@@ -137,15 +137,15 @@ class BaseFileInterface(ABC):
             raise FileExistsError(f"File '{fp}' already exists, choose a different name or write "
                                   "to a different directory.")
         elif Path(fp).is_dir():
-            fp = Path(fp) / self.file_name
+            fp = Path(fp) / (file_prefix + self.file_name)
         elif not Path(fp).parent.is_dir():
             raise FileNotFoundError(f"Parent directory does not exist for '{fp}'.")
-        return fp
+        return Path(fp)
 
     @classmethod
     @abstractmethod
     def default_interface(cls, fp: Union[Path, str]):
-        """Create a defeault interface with the most likely settings for writing.
+        """Create a default interface with the most likely settings for writing.
 
         Parameters
         ----------
@@ -160,7 +160,7 @@ class BaseFileInterface(ABC):
 
     @classmethod
     @abstractmethod
-    def read_file(cls, fp: Union[Path, str]):
+    def read_file(cls, fp: Union[Path, str]) -> tuple[pl.DataFrame, BaseFileInterface]:
         """Create a file interface from a path.
 
         Parameters

--- a/metasyn/metaframe.py
+++ b/metasyn/metaframe.py
@@ -389,6 +389,7 @@ class MetaFrame:
         n: Optional[int] = None,
         seed: Optional[int] = None,
         progress_bar: bool = True,
+        column_prefix: str = "",
     ) -> pl.DataFrame:
         """Create a synthetic Polars dataframe.
 
@@ -429,7 +430,10 @@ class MetaFrame:
             synth_dict[var.name] = var.draw_series(n, synth_dict, seed=None)
 
         synth_dict = {var.name: synth_dict[var.name] for var in self.meta_vars if not var.hidden}
-        return pl.DataFrame(synth_dict)
+        df = pl.DataFrame(synth_dict)
+        if column_prefix == "":
+            return df
+        return df.rename({col: column_prefix + col for col in df.columns})
 
     def write_synthetic(
         self,
@@ -438,6 +442,8 @@ class MetaFrame:
         seed: Optional[int] = None,
         file_format: Union[None, dict, BaseFileInterface] = None,
         overwrite: bool = False,
+        column_prefix: str = "",
+        file_prefix: str = "",
     ):
         """Write a synthetic dataset to a file.
 
@@ -490,9 +496,9 @@ class MetaFrame:
                 " Use write_synthetic(..., file_format=your_file_handler.to_dict())"
             )
         file_handler = file_interface_from_dict(self.file_format)
-        file_handler.check_filename(file_name, overwrite=overwrite)  # Check filename before synth
-        syn_df = self.synthesize(n, seed)
-        file_handler.write_file(syn_df, file_name, overwrite=overwrite)
+        file_handler.check_filename(file_name, overwrite=overwrite, file_prefix=file_prefix)  # Check filename before synth
+        syn_df = self.synthesize(n, seed, column_prefix=column_prefix)
+        file_handler.write_file(syn_df, file_name, overwrite=overwrite, file_prefix=file_prefix)
 
     def __repr__(self) -> str:
         """Return the MetaFrame as it would be output to JSON."""

--- a/metasyn/metaframe.py
+++ b/metasyn/metaframe.py
@@ -496,7 +496,8 @@ class MetaFrame:
                 " Use write_synthetic(..., file_format=your_file_handler.to_dict())"
             )
         file_handler = file_interface_from_dict(self.file_format)
-        file_handler.check_filename(file_name, overwrite=overwrite, file_prefix=file_prefix)  # Check filename before synth
+        # Check whether file exists before synthesis
+        file_handler.check_filename(file_name, overwrite=overwrite, file_prefix=file_prefix)
         syn_df = self.synthesize(n, seed, column_prefix=column_prefix)
         file_handler.write_file(syn_df, file_name, overwrite=overwrite, file_prefix=file_prefix)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -14,6 +14,7 @@ from metasyn.demo.dataset import (
     demo_data,
     demo_file,
 )
+from metasyn.file import CsvFileInterface
 from metasyn.metaframe import MetaFrame
 from metasyn.multiframe import MultiFrame
 from metasyn.privacy import BasicPrivacy
@@ -52,6 +53,7 @@ def test_dataset(tmp_path, dataframe_lib):
     titanic_fp = Path("tests", "data", "titanic.csv")
     tmp_fp = tmp_path / "tmp.json"
     df = _read_csv(titanic_fp, dataframe_lib)
+    _, file_format = CsvFileInterface.read_file(titanic_fp)
     dataset = MetaFrame.fit_dataframe(
         df,
         var_specs=[
@@ -59,7 +61,8 @@ def test_dataset(tmp_path, dataframe_lib):
                 {"name": "Ticket", "description": "test_description"},
                 {"name": "Fare", "distribution": {"name": "normal"}},
                 {"name": "PassengerId", "distribution": {"unique": True}},
-             ])
+             ],
+        file_format=file_format)
 
     def check_dataset(dataset):
         assert dataset.n_columns == 12
@@ -113,9 +116,16 @@ def test_dataset(tmp_path, dataframe_lib):
     assert isinstance(repr(dataset), str)
 
     # Check whether non-columns raise an error
-    with pytest.raises(KeyError):
-        dataset = MetaFrame.fit_dataframe(df, var_specs=[{"name": "unicorn", "prop_missing": 0.5}])
+    with pytest.raises(ValueError):
+        _bad_dataset = MetaFrame.fit_dataframe(df, var_specs=[{"name": "unicorn", "prop_missing": 0.5}])
 
+    dest_path = file_format.check_filename(fp=tmp_path, file_prefix="syn_")
+    dataset.write_synthetic(file_name=tmp_path, file_prefix="syn_", column_prefix="SYNTHETIC_")
+    out_path = Path(tmp_path) / "syn_titanic.csv"
+    assert out_path == dest_path
+    assert out_path.is_file()
+    new_df = pl.read_csv(out_path)
+    assert "SYNTHETIC_PassengerId" in new_df.columns
 
 def test_distributions(tmp_path):
     """Create all available distributions and save a metaframe with it."""

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -116,7 +116,7 @@ def test_dataset(tmp_path, dataframe_lib):
     assert isinstance(repr(dataset), str)
 
     # Check whether non-columns raise an error
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         _bad_dataset = MetaFrame.fit_dataframe(df, var_specs=[{"name": "unicorn", "prop_missing": 0.5}])
 
     dest_path = file_format.check_filename(fp=tmp_path, file_prefix="syn_")

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -104,6 +104,13 @@ def test_sav_warning():
     with pytest.warns(UserWarning):
         SavFileInterface.read_file(Path("tests", "data", "actually_a_sav_file.csv"))
 
+def test_prefix_filename():
+    df, file_format = ms.read_csv(demo_file("fruit"))
+    fp = file_format.check_filename()
+    assert isinstance(fp, Path)
+    assert fp.name == "demo_fruit.csv"
+    fp_2 = file_format.check_filename(file_prefix="syn_")
+    assert fp_2.name == "syn_demo_fruit.csv"
 
 @mark.parametrize("filename",
                   ["SAQ (Item 3 Reversed).sav", "GlastonburyFestival.sav",


### PR DESCRIPTION
This can be helpful for communicating that the synthesized version of the dataset is not the real one.

Both the CLI and API are updated. For the API use:

```python
mf.write_synthetic(file_prefix="SYN_", column_prefix="synthetic_")
```
This will add "SYN_" before the original filename, while the columns are prepended with "synthetic_".

```bash
metasyn synthesize my_gmf_file.json --file-prefix "SYN_" --column-prefix "synthetic_"
```

Does the same for the command line interface.