### PR TITLE
Update maintainers, developers, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,6 @@ Metasyn is an open-source project, and we welcome contributions from the communi
 
 ## Contact
 **Metasyn** is a project by the [ODISSEI Social Data Science (SoDa)](https://odissei-data.nl/nl/soda/) team.
-Do you have questions, suggestions, or remarks on the technical implementation? Create an issue in the [issue tracker](https://github.com/sodascience/metasyn/issues) or feel free to contact [Erik-Jan van Kesteren](https://github.com/vankesteren) or [Raoul Schram](https://github.com/qubixes).
+Do you have questions, suggestions, or remarks on the technical implementation? Create an issue in the [issue tracker](https://github.com/sodascience/metasyn/issues) or feel free to contact [Raoul Schram](https://github.com/qubixes).
 
 <img src="docs/source/images/logos/soda.png" alt="SoDa logo" width="250px"/> 

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -6,7 +6,7 @@ About
 Contact us
 ----------
 
-**Metasyn** is a project by the `ODISSEI Social Data Science (SoDa) <https://odissei-data.nl/nl/soda/>`_ team and is currently being maintained by Erik-Jan van Kesteren, Raoul Schram and Samuel Spithorst.
+**Metasyn** is a project by the `ODISSEI Social Data Science (SoDa) <https://odissei-data.nl/nl/soda/>`_ team and is currently being maintained by Raoul Schram.
 
 .. image:: /images/logos/soda.png
    :alt: SODA_logo
@@ -40,9 +40,17 @@ Maintainers
 
 Feel free to contact one of the maintainers directly:
 
-* Erik-Jan van Kesteren: `https://github.com/vankesteren <https://github.com/vankesteren>`_
-
 * Raoul Schram: `https://github.com/qubixes <https://github.com/qubixes>`_
+
+
+Contributor hall of fame
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Erik-Jan van Kesteren: Former project lead, maintainer and developer
+* Samuel Spithorst: Documentation and user experience
+* Matty Vermet: Developer
+* Maarten Schermer: Developer
+* Raoul Schram: Current maintainer, developer, project lead
 
 License
 -------

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -6,7 +6,8 @@ About
 Contact us
 ----------
 
-**Metasyn** is a project by the `ODISSEI Social Data Science (SoDa) <https://odissei-data.nl/nl/soda/>`_ team and is currently being maintained by Raoul Schram.
+**Metasyn** is a project by the `ODISSEI Social Data Science (SoDa) <https://odissei-data.nl/nl/soda/>`_ team.
+The project was originally started and developed by Erik-Jan van Kesteren and Raoul Schram, and is currently being maintained by Raoul Schram.
 
 .. image:: /images/logos/soda.png
    :alt: SODA_logo

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -42,15 +42,18 @@ Maintainers
 Feel free to contact one of the maintainers directly:
 
 * Raoul Schram: `https://github.com/qubixes <https://github.com/qubixes>`_
+* Matty Vermet: `https://github.com/MSVermet <https://github.com/MSVermet>`_
+* Maarten Schermer: `https://github.com/maartenschermer <https://github.com/maartenschermer>`_
+
 
 
 Contributor hall of fame
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-* Erik-Jan van Kesteren: Former project lead, maintainer and developer
+* Erik-Jan van Kesteren: Original creator, former project lead, maintainer and developer
 * Samuel Spithorst: Documentation and user experience
-* Matty Vermet: Developer
-* Maarten Schermer: Developer
+* Matty Vermet: Current maintainer, developer
+* Maarten Schermer: Current maintainer, developer
 * Raoul Schram: Current maintainer, developer, project lead
 
 License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "setuptools.build_meta"
 name = "metasyn"
 authors = [
     { name = "Raoul Schram", email = "r.d.schram@uu.nl" },
-    { name = "Erik-Jan van Kesteren", email = "e.vankesteren1@uu.nl" },
 ]
 description = "Package for creating synthetic datasets while preserving privacy."
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ authors = [
     { name = "Raoul Schram", email = "r.d.schram@uu.nl" }
 ]
 maintainers = [
-    { name = "Raoul Schram", email = "r.d.schram@uu.nl"}
+    { name = "Raoul Schram", email = "r.d.schram@uu.nl"},
+    { name = "Matty Vermet" },
+    { name = "Maarten Schermer" }
 ]
 description = "Package for creating synthetic datasets while preserving privacy."
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,11 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "metasyn"
 authors = [
-    { name = "Raoul Schram", email = "r.d.schram@uu.nl" },
+    { name = "Erik-Jan van Kesteren" },
+    { name = "Raoul Schram", email = "r.d.schram@uu.nl" }
+]
+maintainers = [
+    { name = "Raoul Schram", email = "r.d.schram@uu.nl"}
 ]
 description = "Package for creating synthetic datasets while preserving privacy."
 readme = "README.md"


### PR DESCRIPTION
I have updated the current list of maintainers, developers. It would be especially nice to get feedback on how (former) developers would like to be mentioned. The current proposal is to put the significant developers into the hall of fame section of the about section in the readthedocs documentation, but any suggestions are welcome! Ideally, everyone approves / suggests a new way of being cited:

- [x] @vankesteren 
- [ ] @Samuwhale 
- [x] @maartenschermer 
- [x] @MSVermet 

Fixes #441